### PR TITLE
Add quarto setup action to CI workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,6 +34,8 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -19,6 +19,8 @@ jobs:
       
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
+      - uses: quarto-dev/quarto-actions/setup@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve support for Quarto documents. The main change is the addition of the Quarto setup step to the R workflow jobs, ensuring that Quarto is available for builds and checks.

**Workflow enhancements for Quarto support:**

* Added `quarto-dev/quarto-actions/setup@v2` to the `.github/workflows/R-CMD-check.yaml` workflow to enable Quarto in R CMD check jobs.
* Added `quarto-dev/quarto-actions/setup@v2` to the `.github/workflows/check-release.yaml` workflow for Quarto support in release checks.
* Added `quarto-dev/quarto-actions/setup@v2` to the `.github/workflows/check-standard.yaml` workflow for Quarto support in standard checks.