### PR TITLE
Fix/pkgdown url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ jsslogo.jpg
 
 inst/doc
 docs
-hviPlotR.Rproj
+hvtiPlotR.Rproj
 
 .Rcheck*
 .Rbuildignore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hvtiPlotR
 Type: Package
 Title: Porting the "plot.sas" macro to R Using ggplot2 and officer Packages
-Version: 1.0.6
-Date: 2026-02-19
+Version: 1.0.7
+Date: 2026-03-17
 Authors@R: c(
     person(
       "John", "Ehrlinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # hvtiPlotR 0.2.2
 
 * Fixed deprecated ggplot2 syntax (size -> linewidth in element_line and element_rect)
-* Removed empty save.hviplotr function
+* Removed empty save.hvtiplotr function
 * Fixed theme_dark_ppt to pass all parameters to theme_grey
 * Updated documentation for data objects
 * Updated README to reference officer package instead of deprecated ReporteRs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## The hvtiPlotR package
 <!-- badges: start -->
+[![CRAN status](https://img.shields.io/github/r-package/v/ehrlinger/hvtiPlotR?label=hvtiPlotR)](https://github.com/ehrlinger/hvtiPlotR)
 [![DOI](https://zenodo.org/badge/5745/ehrlinger/hvtiPlotR.png)](http://dx.doi.org/10.5281/zenodo.11780)
 ![active](http://www.repostatus.org/badges/latest/active.svg)
 [![R-CMD-check](https://github.com/ehrlinger/hvtiPlotR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ehrlinger/hvtiPlotR/actions/workflows/R-CMD-check.yaml)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: http://ehrlinger.github.io/hviPlotR/
+url: https://ehrlinger.github.io/hvtiPlotR/
 template:
   bootstrap: 5
   bslib:


### PR DESCRIPTION
This pull request includes several updates to documentation and configuration files for the `hvtiPlotR` package, mainly focused on correcting references, improving package visibility, and fixing minor issues.

Documentation updates:

* Updated `NEWS.md` to correct the function name from `save.hviplotr` to `save.hvtiplotr` and clarify documentation references.
* Added a CRAN status badge to `README.md` to improve package visibility and monitoring.
* Updated the URL in `_pkgdown.yml` to use the correct package name and HTTPS for the documentation site.
This pull request includes updates to documentation and metadata for the `hvtiPlotR` package, primarily to fix typos, update links, and improve package visibility. The most important changes are grouped below:

Documentation and metadata improvements:

* Corrected a typo in the function removal note in `NEWS.md` from `save.hviplotr` to `save.hvtiplotr`.
* Added a CRAN status badge to the `README.md` to improve package visibility and status tracking.
* Updated the site URL in `_pkgdown.yml` to use the correct package name and HTTPS protocol.