### PR TITLE
Update GitHub Actions to use checkout@v4 and upload-artifact@v4

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to use newer versions of key actions, improving compatibility and ensuring the use of the latest features and security updates.

Workflow dependency updates:

* Updated `actions/checkout` from version 2 to version 4 in `.github/workflows/check-release.yaml`, `.github/workflows/check-standard.yaml`, and `.github/workflows/lint.yaml`. [[1]](diffhunk://#diff-9a53663bd3e9cf34a74e5e379ef9737795a239be679b55f41f2898a8e9701a79L18-R18) [[2]](diffhunk://#diff-de624ca0151c903086de037b3fcdf715ca60137126d03c37cea6a59d5eb037cfL32-R32) [[3]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL17-R17)
* Downgraded `actions/upload-artifact` from version 5 to version 4 in `.github/workflows/test-coverage.yaml`.