### PR TITLE
feat: add articles section to navbar with links to documentation

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -30,20 +30,20 @@ navbar:
     articles:
       text: Articles
       menu:
-      - text: "Getting Started"
-      - text: "The hvtiPlotR Package"
-        href: articles/hvtiPlotR.html
-      - text: "SAS Template Migration Guide"
-        href: articles/sas-migration-guide.html
-      - text: "---"
-      - text: "Plot Functions"
-      - text: "Plot Functions Reference"
-        href: articles/plot-functions.html
-      - text: "Decorating and Saving Plots"
-        href: articles/plot-decorators.html
-      - text: "---"
-      - text: "Contributing to hvtiPlotR"
-        href: articles/contributing.html
+        - text: "Getting Started"
+        - text: "The hvtiPlotR Package"
+          href: articles/hvtiPlotR.html
+        - text: "SAS Template Migration Guide"
+          href: articles/sas-migration-guide.html
+        - text: "---"
+        - text: "Plot Functions"
+        - text: "Plot Functions Reference"
+          href: articles/plot-functions.html
+        - text: "Decorating and Saving Plots"
+          href: articles/plot-decorators.html
+        - text: "---"
+        - text: "Contributing to hvtiPlotR"
+          href: articles/contributing.html
 
 reference:
 - title: "Package Overview"

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,6 +27,23 @@ navbar:
       icon: fa-linkedin
       href: https://www.linkedin.com/in/ehrlinger/
       aria-label: LinkedIn
+    articles:
+      text: Articles
+      menu:
+      - text: "Getting Started"
+      - text: "The hvtiPlotR Package"
+        href: articles/hvtiPlotR.html
+      - text: "SAS Template Migration Guide"
+        href: articles/sas-migration-guide.html
+      - text: "---"
+      - text: "Plot Functions"
+      - text: "Plot Functions Reference"
+        href: articles/plot-functions.html
+      - text: "Decorating and Saving Plots"
+        href: articles/plot-decorators.html
+      - text: "---"
+      - text: "Contributing to hvtiPlotR"
+        href: articles/contributing.html
 
 reference:
 - title: "Package Overview"


### PR DESCRIPTION
This pull request updates the navigation bar configuration in `_pkgdown.yml` to add a new "Articles" dropdown menu. This menu organizes key documentation and guides for the `hvtiPlotR` package, making it easier for users to access important resources directly from the site navigation.

**Navigation improvements:**

* Added an "Articles" dropdown menu to the navbar, including links to getting started guides, package documentation, migration guides, plot function references, and contributing information.