### PR TITLE
Skip UpSet vignette chunks on Windows to fix CI crash

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hvtiPlotR
 Type: Package
 Title: Porting HVTI plot templates and methodology documentation to ggplot2 package in R
-Version: 2.0.0.9009
+Version: 2.0.0.9010
 Date: 2026-04-01
 Authors@R: c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# hvtiPlotR 2.0.0.9010
+
+## Bug fixes
+
+- `plot-functions.qmd`: UpSet plot chunks (`upset_data`, `upset_basic`,
+  `upset_fill`, `upset_era`) now skip on Windows (`eval: !expr
+  .Platform$OS.type != "windows"`). ComplexUpset's patchwork rendering crashes
+  the Rscript subprocess on the Windows CI runner (os error 232 / "pipe being
+  closed"), so the examples are shown only on macOS and Linux where they render
+  reliably.
+
 # hvtiPlotR 2.0.0.9009
 
 ## Documentation

--- a/vignettes/plot-functions.qmd
+++ b/vignettes/plot-functions.qmd
@@ -2411,6 +2411,7 @@ plot(hu) & hv_theme("poster")
 
 ```{r}
 #| label: upset_data
+#| eval: !expr .Platform$OS.type != "windows"
 sets <- c("AV_Replacement", "AV_Repair", "MV_Replacement", "MV_Repair",
           "TV_Repair", "Aorta", "CABG")
 
@@ -2427,6 +2428,7 @@ hu <- hv_upset(upset_dta, intersect = sets)
 #| label: upset_basic
 #| fig-width: 9
 #| fig-height: 5
+#| eval: !expr .Platform$OS.type != "windows"
 plot(hu) &
   hv_theme("poster")
 ```
@@ -2437,6 +2439,7 @@ plot(hu) &
 #| label: upset_fill
 #| fig-width: 9
 #| fig-height: 5
+#| eval: !expr .Platform$OS.type != "windows"
 plot(hu,
      base_annotations = list(
        "Intersection size" = ComplexUpset::intersection_size(
@@ -2457,6 +2460,7 @@ plot(hu,
 #| label: upset_era
 #| fig-width: 9
 #| fig-height: 5
+#| eval: !expr .Platform$OS.type != "windows"
 upset_dta$era <- ifelse(seq_len(nrow(upset_dta)) <= 200, "Early", "Recent")
 hu_era <- hv_upset(upset_dta, intersect = sets)
 


### PR DESCRIPTION
This pull request addresses a bug with UpSet plot rendering in the package's documentation on Windows systems. The main change is to conditionally skip several UpSet plot example chunks in `plot-functions.qmd` when running on Windows, as the ComplexUpset package's patchwork rendering crashes the Rscript subprocess on Windows CI runners. This ensures that examples are only shown on macOS and Linux, where they render reliably.

Bug fixes to documentation examples:

* Added `eval: !expr .Platform$OS.type != "windows"` to UpSet plot chunks (`upset_data`, `upset_basic`, `upset_fill`, `upset_era`) in `plot-functions.qmd` to skip these examples on Windows due to rendering crashes. [[1]](diffhunk://#diff-c8b0767a07c83bb08aa48b04a37cf7183544dd2b351ca6f63b3bc4bfdb2055cbR2414) [[2]](diffhunk://#diff-c8b0767a07c83bb08aa48b04a37cf7183544dd2b351ca6f63b3bc4bfdb2055cbR2431) [[3]](diffhunk://#diff-c8b0767a07c83bb08aa48b04a37cf7183544dd2b351ca6f63b3bc4bfdb2055cbR2442) [[4]](diffhunk://#diff-c8b0767a07c83bb08aa48b04a37cf7183544dd2b351ca6f63b3bc4bfdb2055cbR2463)
* Documented the bug fix and rationale in the `NEWS.md` file under version 2.0.0.9010.

Versioning:

* Bumped the package version to `2.0.0.9010` in the `DESCRIPTION` file to reflect the bug fix.ComplexUpset's patchwork rendering kills the Rscript subprocess on the Windows GitHub Actions runner with os error 232 ("pipe being closed"). Add `eval: !expr .Platform$OS.type != "windows"` to upset_data, upset_basic, upset_fill, and upset_era so those chunks are skipped on Windows but still run on macOS and Linux.

Bumps version to 2.0.0.9010.