### PR TITLE
feat: add emp_geom parameter for empirical overlay options in hazard …

### DIFF
--- a/R/hazard-plot.R
+++ b/R/hazard-plot.R
@@ -533,6 +533,8 @@ sample_nnt_data <- function(n        = 500,
 #'   or `NULL`. Default `NULL`.
 #' @param emp_group_col Column name for grouping in `empirical`. Default: same
 #'   as `group_col`.
+#' @param emp_geom     Geom used for the empirical overlay: `"point"`
+#'   (default, open circles) or `"step"` (Kaplan-Meier step function).
 #' @param reference    Optional data frame of population life-table survival
 #'   curves. Corresponds to the SAS `smatched` / `hmatched` datasets. See
 #'   [sample_life_table()]. Rendered as dashed lines. Default `NULL`.
@@ -857,6 +859,7 @@ hazard_plot <- function(curve_data,
                          emp_lower_col    = NULL,
                          emp_upper_col    = NULL,
                          emp_group_col    = group_col,
+                         emp_geom         = c("point", "step"),
                          reference        = NULL,
                          ref_x_col        = x_col,
                          ref_estimate_col = estimate_col,
@@ -866,6 +869,8 @@ hazard_plot <- function(curve_data,
                          point_size       = 2.0,
                          point_shape      = 1L,
                          errorbar_width   = 0.25) {
+
+  emp_geom <- match.arg(emp_geom)
 
   # --- Validate curve_data --------------------------------------------------
   .check_df(curve_data, "curve_data")
@@ -947,7 +952,7 @@ hazard_plot <- function(curve_data,
     }
   }
 
-  # --- KM empirical points --------------------------------------------------
+  # --- KM empirical overlay --------------------------------------------------
   if (!is.null(empirical)) {
     if (!is.null(emp_group_col)) {
       emp_aes <- ggplot2::aes(x      = .data[[emp_x_col]],
@@ -957,11 +962,19 @@ hazard_plot <- function(curve_data,
       emp_aes <- ggplot2::aes(x = .data[[emp_x_col]],
                               y = .data[[emp_estimate_col]])
     }
-    p <- p + ggplot2::geom_point(mapping     = emp_aes,
-                                 data        = empirical,
-                                 size        = point_size,
-                                 shape       = point_shape,
-                                 inherit.aes = FALSE)
+
+    if (emp_geom == "step") {
+      p <- p + ggplot2::geom_step(mapping     = emp_aes,
+                                  data        = empirical,
+                                  linewidth   = line_width * 0.7,
+                                  inherit.aes = FALSE)
+    } else {
+      p <- p + ggplot2::geom_point(mapping     = emp_aes,
+                                   data        = empirical,
+                                   size        = point_size,
+                                   shape       = point_shape,
+                                   inherit.aes = FALSE)
+    }
 
     # --- Error bars on empirical points -------------------------------------
     if (!is.null(emp_lower_col) && !is.null(emp_upper_col)) {
@@ -1276,6 +1289,8 @@ nnt_plot <- function(nnt_data,
 #' @param emp_upper_col  Upper error-bar column in `empirical`, or `NULL`.
 #'   Default `NULL`.
 #' @param emp_group_col  Group column in `empirical`. Defaults to `group_col`.
+#' @param emp_geom       Geom used for the empirical overlay: `"point"`
+#'   (default, open circles) or `"step"` (Kaplan-Meier step function).
 #' @param reference      Optional data frame of population life-table curves
 #'   (SAS `smatched` dataset). Stored in `$tables$reference`. Default `NULL`.
 #' @param ref_x_col      x column in `reference`. Defaults to `x_col`.
@@ -1368,10 +1383,13 @@ hv_hazard <- function(curve_data,
                         emp_lower_col    = NULL,
                         emp_upper_col    = NULL,
                         emp_group_col    = group_col,
+                        emp_geom         = c("point", "step"),
                         reference        = NULL,
                         ref_x_col        = x_col,
                         ref_estimate_col = estimate_col,
                         ref_group_col    = NULL) {
+
+  emp_geom <- match.arg(emp_geom)
 
   # --- Validate curve_data --------------------------------------------------
   .check_df(curve_data, "curve_data")
@@ -1410,6 +1428,7 @@ hv_hazard <- function(curve_data,
       emp_lower_col    = emp_lower_col,
       emp_upper_col    = emp_upper_col,
       emp_group_col    = emp_group_col,
+      emp_geom         = emp_geom,
       ref_x_col        = ref_x_col,
       ref_estimate_col = ref_estimate_col,
       ref_group_col    = ref_group_col
@@ -1458,6 +1477,8 @@ print.hv_hazard <- function(x, ...) {
 #' @param ci_alpha      Transparency of the CI ribbon. Default `0.20`.
 #' @param line_width    Width of the parametric curve line. Default `1.0`.
 #' @param point_size    Size of empirical overlay points. Default `2.0`.
+#' @param point_size    Size of empirical overlay points (used when
+#'   `emp_geom = "point"` was set in [hv_hazard()]). Default `2.0`.
 #' @param point_shape   Shape code for empirical points (`1` = open circle,
 #'   `0` = open square). Default `1`.
 #' @param errorbar_width Width of error bars on empirical points. Default
@@ -1472,7 +1493,7 @@ print.hv_hazard <- function(x, ...) {
 #'
 #' @family Hazard plot
 #'
-#' @importFrom ggplot2 ggplot aes geom_line geom_ribbon geom_point geom_errorbar
+#' @importFrom ggplot2 ggplot aes geom_line geom_step geom_ribbon geom_point geom_errorbar
 #' @importFrom rlang .data
 #' @export
 plot.hv_hazard <- function(x,
@@ -1555,13 +1576,14 @@ plot.hv_hazard <- function(x,
     }
   }
 
-  # --- KM empirical points --------------------------------------------------
+  # --- KM empirical overlay --------------------------------------------------
   if (!is.null(empirical)) {
     emp_x_col        <- m$emp_x_col
     emp_estimate_col <- m$emp_estimate_col
     emp_lower_col    <- m$emp_lower_col
     emp_upper_col    <- m$emp_upper_col
     emp_group_col    <- m$emp_group_col
+    emp_geom         <- if (!is.null(m$emp_geom)) m$emp_geom else "point"
 
     if (!is.null(emp_group_col)) {
       emp_aes <- ggplot2::aes(x      = .data[[emp_x_col]],
@@ -1571,11 +1593,19 @@ plot.hv_hazard <- function(x,
       emp_aes <- ggplot2::aes(x = .data[[emp_x_col]],
                               y = .data[[emp_estimate_col]])
     }
-    p <- p + ggplot2::geom_point(mapping     = emp_aes,
-                                 data        = empirical,
-                                 size        = point_size,
-                                 shape       = point_shape,
-                                 inherit.aes = FALSE)
+
+    if (emp_geom == "step") {
+      p <- p + ggplot2::geom_step(mapping     = emp_aes,
+                                  data        = empirical,
+                                  linewidth   = line_width * 0.7,
+                                  inherit.aes = FALSE)
+    } else {
+      p <- p + ggplot2::geom_point(mapping     = emp_aes,
+                                   data        = empirical,
+                                   size        = point_size,
+                                   shape       = point_shape,
+                                   inherit.aes = FALSE)
+    }
 
     if (!is.null(emp_lower_col) && !is.null(emp_upper_col)) {
       if (!is.null(emp_group_col)) {

--- a/man/hazard_plot.Rd
+++ b/man/hazard_plot.Rd
@@ -17,6 +17,7 @@ hazard_plot(
   emp_lower_col = NULL,
   emp_upper_col = NULL,
   emp_group_col = group_col,
+  emp_geom = c("point", "step"),
   reference = NULL,
   ref_x_col = x_col,
   ref_estimate_col = estimate_col,
@@ -68,6 +69,9 @@ or \code{NULL}. Default \code{NULL}.}
 
 \item{emp_group_col}{Column name for grouping in \code{empirical}. Default: same
 as \code{group_col}.}
+
+\item{emp_geom}{Geom used for the empirical overlay: \code{"point"}
+(default, open circles) or \code{"step"} (Kaplan-Meier step function).}
 
 \item{reference}{Optional data frame of population life-table survival
 curves. Corresponds to the SAS \code{smatched} / \code{hmatched} datasets. See

--- a/man/hv_hazard.Rd
+++ b/man/hv_hazard.Rd
@@ -17,6 +17,7 @@ hv_hazard(
   emp_lower_col = NULL,
   emp_upper_col = NULL,
   emp_group_col = group_col,
+  emp_geom = c("point", "step"),
   reference = NULL,
   ref_x_col = x_col,
   ref_estimate_col = estimate_col,
@@ -56,6 +57,9 @@ Default \code{NULL}.}
 Default \code{NULL}.}
 
 \item{emp_group_col}{Group column in \code{empirical}. Defaults to \code{group_col}.}
+
+\item{emp_geom}{Geom used for the empirical overlay: \code{"point"}
+(default, open circles) or \code{"step"} (Kaplan-Meier step function).}
 
 \item{reference}{Optional data frame of population life-table curves
 (SAS \code{smatched} dataset). Stored in \verb{$tables$reference}. Default \code{NULL}.}

--- a/man/plot.hv_hazard.Rd
+++ b/man/plot.hv_hazard.Rd
@@ -21,7 +21,8 @@
 
 \item{line_width}{Width of the parametric curve line. Default \code{1.0}.}
 
-\item{point_size}{Size of empirical overlay points. Default \code{2.0}.}
+\item{point_size}{Size of empirical overlay points (used when
+\code{emp_geom = "point"} was set in \code{\link[=hv_hazard]{hv_hazard()}}). Default \code{2.0}.}
 
 \item{point_shape}{Shape code for empirical points (\code{1} = open circle,
 \code{0} = open square). Default \code{1}.}


### PR DESCRIPTION
This pull request adds support for customizing the empirical overlay in hazard plots and related functions, allowing users to choose between plotting empirical data as points or as a Kaplan-Meier step function. The changes update both the implementation and documentation for `hazard_plot()`, `hv_hazard()`, and their plotting methods to support a new `emp_geom` argument.

**Empirical overlay customization:**

* Added a new `emp_geom` argument to `hazard_plot()`, `hv_hazard()`, and related plotting functions, allowing users to specify `"point"` (default, open circles) or `"step"` (Kaplan-Meier step function) for the empirical overlay (`R/hazard-plot.R`, `man/hazard_plot.Rd`, `man/hv_hazard.Rd`). [[1]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R536-R537) [[2]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R862) [[3]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R873-R874) [[4]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R1386-R1393) [[5]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R1431) [[6]](diffhunk://#diff-59caa36a379f181c0b4a9983f1aa7e7b2881189c60a1ed466a4e856652a0c3e2R20) [[7]](diffhunk://#diff-59caa36a379f181c0b4a9983f1aa7e7b2881189c60a1ed466a4e856652a0c3e2R61-R63) [[8]](diffhunk://#diff-12dd153718dc9ed494ee88d10dde2b6de27e28d87b5b8d275a462e2ca05790d9R20) [[9]](diffhunk://#diff-12dd153718dc9ed494ee88d10dde2b6de27e28d87b5b8d275a462e2ca05790d9R73-R75)
* Updated the plotting logic in `hazard_plot()` and `plot.hv_hazard()` to use `geom_step` when `emp_geom = "step"`, and `geom_point` otherwise. The line width for steps is scaled appropriately (`R/hazard-plot.R`). [[1]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242L950-R955) [[2]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R965-R977) [[3]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242L1558-R1586) [[4]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R1596-R1608)
* Updated documentation to describe the new `emp_geom` argument and clarify the use of `point_size` when `emp_geom = "point"` (`man/hazard_plot.Rd`, `man/hv_hazard.Rd`, `man/plot.hv_hazard.Rd`). [[1]](diffhunk://#diff-52ff70cb32ceac6e7cf9fdfc01b7fde215f16f14cd4613f39afce7b172a91c40L24-R25) [[2]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242R1480-R1481)

**Other improvements:**

* Improved code comments and section headings for clarity (e.g., renaming "KM empirical points" to "KM empirical overlay") (`R/hazard-plot.R`). [[1]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242L950-R955) [[2]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242L1558-R1586)
* Updated import statements to include `geom_step` where necessary (`R/hazard-plot.R`).…plots