### PR TITLE
feat: add emp_geom condition for error bars in hazard plot functions

### DIFF
--- a/R/hazard-plot.R
+++ b/R/hazard-plot.R
@@ -976,8 +976,9 @@ hazard_plot <- function(curve_data,
                                    inherit.aes = FALSE)
     }
 
-    # --- Error bars on empirical points -------------------------------------
-    if (!is.null(emp_lower_col) && !is.null(emp_upper_col)) {
+    # --- Error bars (point geom only) -----------------------------------------
+    if (emp_geom == "point" &&
+        !is.null(emp_lower_col) && !is.null(emp_upper_col)) {
       if (!is.null(emp_group_col)) {
         err_aes <- ggplot2::aes(x      = .data[[emp_x_col]],
                                 y      = .data[[emp_estimate_col]],
@@ -1607,7 +1608,9 @@ plot.hv_hazard <- function(x,
                                    inherit.aes = FALSE)
     }
 
-    if (!is.null(emp_lower_col) && !is.null(emp_upper_col)) {
+    # --- Error bars (point geom only) -----------------------------------------
+    if (emp_geom == "point" &&
+        !is.null(emp_lower_col) && !is.null(emp_upper_col)) {
       if (!is.null(emp_group_col)) {
         err_aes <- ggplot2::aes(x      = .data[[emp_x_col]],
                                 y      = .data[[emp_estimate_col]],

--- a/tests/testthat/test_hazard_plot.R
+++ b/tests/testthat/test_hazard_plot.R
@@ -271,6 +271,17 @@ test_that("hv_hazard $tables$empirical is NULL when not supplied", {
   expect_null(obj$tables$reference)
 })
 
+test_that("hv_hazard stores emp_geom in $meta", {
+  dat <- sample_hazard_data(n = 50, seed = 1)
+  emp <- sample_hazard_empirical(n = 50, seed = 1)
+
+  obj_default <- hv_hazard(dat, empirical = emp)
+  obj_step    <- hv_hazard(dat, empirical = emp, emp_geom = "step")
+
+  expect_equal(obj_default$meta$emp_geom, "point")
+  expect_equal(obj_step$meta$emp_geom, "step")
+})
+
 # ============================================================================
 # hv_hazard — plot() return type
 # ============================================================================
@@ -346,6 +357,34 @@ test_that("plot.hv_hazard with empirical error bars has a GeomErrorbar layer", {
   )
   expect_true("GeomPoint"    %in% geoms)
   expect_true("GeomErrorbar" %in% geoms)
+})
+
+test_that("plot.hv_hazard with emp_geom='step' adds a GeomStep layer", {
+  dat   <- sample_hazard_data(n = 50, seed = 1)
+  emp   <- sample_hazard_empirical(n = 50, seed = 1)
+  geoms <- sapply(
+    plot(hv_hazard(dat, empirical = emp, emp_geom = "step"))$layers,
+    function(l) class(l$geom)[1]
+  )
+
+  expect_true("GeomStep" %in% geoms)
+  expect_false("GeomPoint" %in% geoms)
+})
+
+test_that("plot.hv_hazard with emp_geom='step' does not add GeomErrorbar", {
+  dat   <- sample_hazard_data(n = 50, seed = 1)
+  emp   <- sample_hazard_empirical(n = 50, seed = 1)
+  geoms <- sapply(
+    plot(hv_hazard(dat,
+                     empirical     = emp,
+                     emp_lower_col = "lower",
+                     emp_upper_col = "upper",
+                     emp_geom      = "step"))$layers,
+    function(l) class(l$geom)[1]
+  )
+
+  expect_true("GeomStep" %in% geoms)
+  expect_false("GeomErrorbar" %in% geoms)
 })
 
 test_that("plot.hv_hazard with reference life table adds extra GeomLine layer", {


### PR DESCRIPTION
This pull request improves how empirical hazard estimates are plotted by adding support for a "step" geometry and ensuring error bars are only shown with point geoms. It also adds tests to verify the new behavior and the correct storage of the geometry type.

**Empirical hazard plot improvements:**

* Error bars are now only added when the empirical geometry is `"point"`, preventing them from appearing with other geoms like `"step"` (`hazard_plot`, `plot.hv_hazard`). [[1]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242L979-R981) [[2]](diffhunk://#diff-594a5f4f4212d0ebd4fdac720f16b7f9f72ec61c190af1490b0a796fbc9b3242L1610-R1613)
* Added support for plotting empirical hazards as steps (`emp_geom = "step"`), and ensured only the appropriate geom is added in each case.

**Testing enhancements:**

* Added tests to confirm that `emp_geom` is stored in the object metadata and that the correct geom layers are present (e.g., `GeomStep` for step, `GeomPoint` for point, and no `GeomErrorbar` for step). [[1]](diffhunk://#diff-47f582cb00e003a552b6ccf9b733f9066999a018a239ca3b6450868a90e9b05cR274-R284) [[2]](diffhunk://#diff-47f582cb00e003a552b6ccf9b733f9066999a018a239ca3b6450868a90e9b05cR362-R389)