### PR TITLE
feat(themes): PPT themes adopt AATS-style defaults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hvtiPlotR
 Type: Package
 Title: Porting HVTI plot templates and methodology documentation to ggplot2 package in R
-Version: 2.0.0.9012
-Date: 2026-04-20
+Version: 2.0.0.9013
+Date: 2026-04-21
 Authors@R: c(
     person(
       "John", "Ehrlinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+# hvtiPlotR 2.0.0.9013
+
+## Behaviour changes
+
+- `hv_theme_dark_ppt()` and `hv_theme_light_ppt()`:
+  - Legend is now hidden by default (`legend.position = "none"`).
+    PowerPoint figures are typically annotated directly on the panel;
+    override with `+ theme(legend.position = "right")` when needed.
+  - Axis ticks now face **inside** the panel (`axis.ticks.length =
+    -half_line/2 pt`) for the AATS-style inset look.
+  - Axis-text and axis-title margins are now scaled from `base_size`
+    via ggplot2's `half_line = base_size / 2` convention, so spacing
+    stays proportional when `base_size` changes. Previous unscaled
+    defaults produced cramped labels at `base_size = 32`.
+
+## New features
+
+- `hv_theme_dark_ppt(bold = TRUE)` / `hv_theme_light_ppt(bold = TRUE)`:
+  apply `face = "bold"` to axis text and axis titles. Default
+  `bold = FALSE` preserves the prior appearance.
+
 # hvtiPlotR 2.0.0.9012
 
 ## New features

--- a/R/save_ppt.R
+++ b/R/save_ppt.R
@@ -161,8 +161,8 @@ add_plot_slide <- function(doc, plot, title, layout, master, width, height,
 #' # panel inside a fixed ph_location(). On dark_ppt the black panel box
 #' # appears to drift between slides — visually jarring.
 #' #
-#' # Solution: pass `panel_box = list(width, height, left, top)`. This
-#' # describes the PANEL CONTENT AREA itself — the rectangle bounded by
+#' # Solution: pass `panel_box = list(width = ..., height = ..., left = ...,
+#' # top = ...)`. This describes the PANEL CONTENT AREA itself — the rectangle bounded by
 #' # the axis lines, not the outer plot extent. save_ppt() calls
 #' # [hv_ph_location()] for each plot, measures the axis / title / legend
 #' # chrome around the panel, and adjusts per-slide placement so the
@@ -204,8 +204,8 @@ add_plot_slide <- function(doc, plot, title, layout, master, width, height,
 #' )
 #'
 #' # Sizing advice: panel_left and panel_top must be large enough for the
-#' # widest axis labels in the deck. If chrome spills off the slide edge,
-#' # hv_ph_location() emits a warning naming the offending edge.
+#' # widest axis labels in the deck. If chrome extends past the left or top
+#' # slide edge, hv_ph_location() emits a warning naming that edge.
 #' }
 #'
 #' @importFrom officer read_pptx add_slide ph_with ph_location ph_location_type

--- a/R/save_ppt.R
+++ b/R/save_ppt.R
@@ -151,6 +151,61 @@ add_plot_slide <- function(doc, plot, title, layout, master, width, height,
 #'   powerpoint   = "graphs/manuscript.pptx",
 #'   slide_titles = "Fuel Economy"
 #' )
+#'
+#' # ----------------------------------------------------------------------
+#' # panel_box: anchor the plot panel to a fixed rectangle on every slide
+#' # ----------------------------------------------------------------------
+#' #
+#' # Problem: when plots in a deck have different y-axis ranges
+#' # (e.g. "1.0" vs "4567.2"), axis-label widths differ and shift the
+#' # panel inside a fixed ph_location(). On dark_ppt the black panel box
+#' # appears to drift between slides — visually jarring.
+#' #
+#' # Solution: pass `panel_box = list(width, height, left, top)`. This
+#' # describes the PANEL CONTENT AREA itself — the rectangle bounded by
+#' # the axis lines, not the outer plot extent. save_ppt() calls
+#' # [hv_ph_location()] for each plot, measures the axis / title / legend
+#' # chrome around the panel, and adjusts per-slide placement so the
+#' # panel lands at the target rectangle on every slide. The plot's
+#' # OUTER dimensions therefore vary per slide (chrome floats around a
+#' # constant panel), analogous to how [hv_ggsave_dims()] drives ggsave's
+#' # width/height from a target panel size.
+#'
+#' p_small <- ggplot(mtcars, aes(hp, mpg)) +
+#'   geom_point() +
+#'   scale_y_continuous(labels = function(x) sprintf("%3.1f", x)) +
+#'   labs(x = "Horsepower", y = "MPG") +
+#'   hv_theme("dark_ppt")
+#'
+#' p_big <- ggplot(mtcars, aes(hp, mpg)) +
+#'   geom_point() +
+#'   scale_y_continuous(labels = function(x) sprintf("%8.1f", x * 10000)) +
+#'   labs(x = "Horsepower", y = "MPG (x10k)") +
+#'   hv_theme("dark_ppt")
+#'
+#' # Without panel_box: panel drifts between slides because the big-number
+#' # labels eat more horizontal space than the small-number labels.
+#' save_ppt(
+#'   object       = list(p_small, p_big),
+#'   template     = "graphs/RD.pptx",
+#'   powerpoint   = "graphs/drifting_deck.pptx",
+#'   slide_titles = c("Small y-axis", "Big y-axis")
+#' )
+#'
+#' # With panel_box: target is a 10" x 5" panel at slide coordinates
+#' # (1.5", 1.5"). The panel content area lands at exactly that rectangle
+#' # on both slides; axis labels extend outside it as each plot requires.
+#' save_ppt(
+#'   object       = list(p_small, p_big),
+#'   template     = "graphs/RD.pptx",
+#'   powerpoint   = "graphs/anchored_deck.pptx",
+#'   slide_titles = c("Small y-axis", "Big y-axis"),
+#'   panel_box    = list(width = 10, height = 5, left = 1.5, top = 1.5)
+#' )
+#'
+#' # Sizing advice: panel_left and panel_top must be large enough for the
+#' # widest axis labels in the deck. If chrome spills off the slide edge,
+#' # hv_ph_location() emits a warning naming the offending edge.
 #' }
 #'
 #' @importFrom officer read_pptx add_slide ph_with ph_location ph_location_type

--- a/R/theme_dark_ppt.R
+++ b/R/theme_dark_ppt.R
@@ -6,6 +6,12 @@
 #' For a light-background variant use [hv_theme_light_ppt()].
 #' Removes grid lines and panel borders.
 #'
+#' Legend is hidden by default since PowerPoint figures are typically
+#' annotated directly on the panel; add `+ theme(legend.position = "right")`
+#' (or similar) to override. Axis-text and axis-title margins are scaled from
+#' `base_size` via ggplot2's `half_line = base_size / 2` convention, so the
+#' spacing stays proportional when `base_size` changes.
+#'
 #' @param base_size      Base font size in points.
 #'   Default `32`.
 #' @param base_family    Base font family. Default `""` (device default).
@@ -18,6 +24,8 @@
 #' @param paper          Background colour. Default `"transparent"`.
 #' @param accent         Accent colour used by some `theme_grey()` elements.
 #'   Default `"#3366FF"`.
+#' @param bold           If `TRUE`, axis text and axis titles are rendered
+#'   with `face = "bold"`. Default `FALSE`.
 #'
 #' @return A [ggplot2::theme()] object.
 #'
@@ -33,6 +41,12 @@
 #'
 #' # Via alias
 #' p + theme_ppt()
+#'
+#' # Bold axis text/titles
+#' p + hv_theme_dark_ppt(bold = TRUE)
+#'
+#' # Override the default hidden legend
+#' p + hv_theme_dark_ppt() + theme(legend.position = "right")
 #'
 #' \dontrun{
 #' # Best viewed against a dark slide background
@@ -50,7 +64,11 @@ hv_theme_dark_ppt <- function(base_size      = 32,
                                 base_rect_size = base_size / 22,
                                 ink            = "white",
                                 paper          = "transparent",
-                                accent         = "#3366FF") {
+                                accent         = "#3366FF",
+                                bold           = FALSE) {
+  half_line <- base_size / 2
+  face_axis <- if (isTRUE(bold)) "bold" else "plain"
+
   hv_theme_base(
     base_size      = base_size,
     base_family    = base_family,
@@ -67,8 +85,28 @@ hv_theme_dark_ppt <- function(base_size      = 32,
         colour    = "transparent",
         linewidth = 2
       ),
-      axis.text          = element_text(size = base_size, color = "white"),
-      axis.line          = element_line(color = "white", linewidth = 1),
+      axis.text          = element_text(
+        size   = base_size,
+        colour = "white",
+        face   = face_axis
+      ),
+      axis.text.x        = element_text(
+        margin = margin(t = half_line)
+      ),
+      axis.text.y        = element_text(
+        margin = margin(r = half_line),
+        hjust  = 1
+      ),
+      axis.title.x       = element_text(
+        face   = face_axis,
+        margin = margin(t = 1.5 * half_line)
+      ),
+      axis.title.y       = element_text(
+        angle  = 90,
+        face   = face_axis,
+        margin = margin(r = 1.5 * half_line)
+      ),
+      axis.line          = element_line(colour = "white", linewidth = 1),
       strip.text         = element_text(size = base_size / 2),
       panel.border       = element_blank(),
       panel.background   = element_rect(
@@ -77,9 +115,11 @@ hv_theme_dark_ppt <- function(base_size      = 32,
         linewidth = 1
       ),
       axis.ticks         = element_line(colour = "white", linewidth = 1),
+      axis.ticks.length  = unit(-half_line / 2, "pt"),
       panel.grid.major.x = element_blank(),
       panel.grid.major.y = element_blank(),
       panel.grid.minor   = element_blank(),
+      legend.position    = "none",
       plot.margin        = unit(c(0, 0, 0, 0), "inches")
     )
 }

--- a/R/theme_light_ppt.R
+++ b/R/theme_light_ppt.R
@@ -81,8 +81,9 @@ hv_theme_light_ppt <- function(base_size      = 32,
         linewidth = 2
       ),
       axis.text          = element_text(
-        size = base_size,
-        face = face_axis
+        size   = base_size,
+        colour = "black",
+        face   = face_axis
       ),
       axis.text.x        = element_text(
         margin = margin(t = half_line)
@@ -100,9 +101,16 @@ hv_theme_light_ppt <- function(base_size      = 32,
         face   = face_axis,
         margin = margin(r = 1.5 * half_line)
       ),
-      axis.ticks.length  = unit(-half_line / 2, "pt"),
+      axis.line          = element_line(colour = "black", linewidth = 1),
       strip.text         = element_text(size = base_size / 2),
       panel.border       = element_blank(),
+      panel.background   = element_rect(
+        fill      = "white",
+        colour    = "black",
+        linewidth = 1
+      ),
+      axis.ticks         = element_line(colour = "black", linewidth = 1),
+      axis.ticks.length  = unit(-half_line / 2, "pt"),
       panel.grid.major.x = element_blank(),
       panel.grid.major.y = element_blank(),
       panel.grid.minor   = element_blank(),

--- a/R/theme_light_ppt.R
+++ b/R/theme_light_ppt.R
@@ -7,6 +7,12 @@
 #' For the default dark-background PowerPoint theme use
 #' [hv_theme_dark_ppt()] or its alias `hv_theme_ppt()`.
 #'
+#' Legend is hidden by default since PowerPoint figures are typically
+#' annotated directly on the panel; add `+ theme(legend.position = "right")`
+#' (or similar) to override. Axis-text and axis-title margins are scaled from
+#' `base_size` via ggplot2's `half_line = base_size / 2` convention, so the
+#' spacing stays proportional when `base_size` changes.
+#'
 #' @param base_size      Base font size in points.
 #'   Default `32`.
 #' @param base_family    Base font family. Default `""` (device default).
@@ -19,6 +25,8 @@
 #' @param paper          Background colour. Default `"transparent"`.
 #' @param accent         Accent colour used by some `theme_grey()` elements.
 #'   Default `"#3366FF"`.
+#' @param bold           If `TRUE`, axis text and axis titles are rendered
+#'   with `face = "bold"`. Default `FALSE`.
 #'
 #' @return A [ggplot2::theme()] object.
 #'
@@ -35,6 +43,9 @@
 #' # Via alias
 #' p + theme_light_ppt()
 #'
+#' # Bold axis text/titles
+#' p + hv_theme_light_ppt(bold = TRUE)
+#'
 #' # Via the generic dispatcher
 #' p + hv_theme("light_ppt")
 #'
@@ -48,7 +59,11 @@ hv_theme_light_ppt <- function(base_size      = 32,
                                   base_rect_size = base_size / 22,
                                   ink            = "black",
                                   paper          = "transparent",
-                                  accent         = "#3366FF") {
+                                  accent         = "#3366FF",
+                                  bold           = FALSE) {
+  half_line <- base_size / 2
+  face_axis <- if (isTRUE(bold)) "bold" else "plain"
+
   hv_theme_base(
     base_size      = base_size,
     base_family    = base_family,
@@ -65,11 +80,33 @@ hv_theme_light_ppt <- function(base_size      = 32,
         colour    = "transparent",
         linewidth = 2
       ),
+      axis.text          = element_text(
+        size = base_size,
+        face = face_axis
+      ),
+      axis.text.x        = element_text(
+        margin = margin(t = half_line)
+      ),
+      axis.text.y        = element_text(
+        margin = margin(r = half_line),
+        hjust  = 1
+      ),
+      axis.title.x       = element_text(
+        face   = face_axis,
+        margin = margin(t = 1.5 * half_line)
+      ),
+      axis.title.y       = element_text(
+        angle  = 90,
+        face   = face_axis,
+        margin = margin(r = 1.5 * half_line)
+      ),
+      axis.ticks.length  = unit(-half_line / 2, "pt"),
       strip.text         = element_text(size = base_size / 2),
       panel.border       = element_blank(),
       panel.grid.major.x = element_blank(),
       panel.grid.major.y = element_blank(),
       panel.grid.minor   = element_blank(),
+      legend.position    = "none",
       plot.margin        = unit(c(0, 0, 0, 0), "inches")
     )
 }

--- a/man/hv_theme_dark_ppt.Rd
+++ b/man/hv_theme_dark_ppt.Rd
@@ -15,7 +15,8 @@ hv_theme_dark_ppt(
   base_rect_size = base_size/22,
   ink = "white",
   paper = "transparent",
-  accent = "#3366FF"
+  accent = "#3366FF",
+  bold = FALSE
 )
 
 theme_dark_ppt(
@@ -26,7 +27,8 @@ theme_dark_ppt(
   base_rect_size = base_size/22,
   ink = "white",
   paper = "transparent",
-  accent = "#3366FF"
+  accent = "#3366FF",
+  bold = FALSE
 )
 
 theme_ppt(
@@ -37,7 +39,8 @@ theme_ppt(
   base_rect_size = base_size/22,
   ink = "white",
   paper = "transparent",
-  accent = "#3366FF"
+  accent = "#3366FF",
+  bold = FALSE
 )
 
 hv_theme_ppt(
@@ -48,7 +51,8 @@ hv_theme_ppt(
   base_rect_size = base_size/22,
   ink = "white",
   paper = "transparent",
-  accent = "#3366FF"
+  accent = "#3366FF",
+  bold = FALSE
 )
 }
 \arguments{
@@ -71,6 +75,9 @@ Default \code{base_size / 22}.}
 
 \item{accent}{Accent colour used by some \code{theme_grey()} elements.
 Default \code{"#3366FF"}.}
+
+\item{bold}{If \code{TRUE}, axis text and axis titles are rendered
+with \code{face = "bold"}. Default \code{FALSE}.}
 }
 \value{
 A \code{\link[ggplot2:theme]{ggplot2::theme()}} object.
@@ -82,6 +89,13 @@ to dark-mode PowerPoint slides. This is the default hvtiPlotR PPT theme —
 For a light-background variant use \code{\link[=hv_theme_light_ppt]{hv_theme_light_ppt()}}.
 Removes grid lines and panel borders.
 }
+\details{
+Legend is hidden by default since PowerPoint figures are typically
+annotated directly on the panel; add \code{+ theme(legend.position = "right")}
+(or similar) to override. Axis-text and axis-title margins are scaled from
+\code{base_size} via ggplot2's \code{half_line = base_size / 2} convention, so the
+spacing stays proportional when \code{base_size} changes.
+}
 \examples{
 library(ggplot2)
 p <- ggplot(mtcars, aes(wt, mpg, colour = factor(cyl))) + geom_point()
@@ -91,6 +105,12 @@ p + hv_theme_dark_ppt()
 
 # Via alias
 p + theme_ppt()
+
+# Bold axis text/titles
+p + hv_theme_dark_ppt(bold = TRUE)
+
+# Override the default hidden legend
+p + hv_theme_dark_ppt() + theme(legend.position = "right")
 
 \dontrun{
 # Best viewed against a dark slide background

--- a/man/hv_theme_light_ppt.Rd
+++ b/man/hv_theme_light_ppt.Rd
@@ -13,7 +13,8 @@ hv_theme_light_ppt(
   base_rect_size = base_size/22,
   ink = "black",
   paper = "transparent",
-  accent = "#3366FF"
+  accent = "#3366FF",
+  bold = FALSE
 )
 
 theme_light_ppt(
@@ -24,7 +25,8 @@ theme_light_ppt(
   base_rect_size = base_size/22,
   ink = "black",
   paper = "transparent",
-  accent = "#3366FF"
+  accent = "#3366FF",
+  bold = FALSE
 )
 }
 \arguments{
@@ -47,6 +49,9 @@ Default \code{base_size / 22}.}
 
 \item{accent}{Accent colour used by some \code{theme_grey()} elements.
 Default \code{"#3366FF"}.}
+
+\item{bold}{If \code{TRUE}, axis text and axis titles are rendered
+with \code{face = "bold"}. Default \code{FALSE}.}
 }
 \value{
 A \code{\link[ggplot2:theme]{ggplot2::theme()}} object.
@@ -59,6 +64,12 @@ and panel borders.
 \details{
 For the default dark-background PowerPoint theme use
 \code{\link[=hv_theme_dark_ppt]{hv_theme_dark_ppt()}} or its alias \code{hv_theme_ppt()}.
+
+Legend is hidden by default since PowerPoint figures are typically
+annotated directly on the panel; add \code{+ theme(legend.position = "right")}
+(or similar) to override. Axis-text and axis-title margins are scaled from
+\code{base_size} via ggplot2's \code{half_line = base_size / 2} convention, so the
+spacing stays proportional when \code{base_size} changes.
 }
 \examples{
 library(ggplot2)
@@ -69,6 +80,9 @@ p + hv_theme_light_ppt()
 
 # Via alias
 p + theme_light_ppt()
+
+# Bold axis text/titles
+p + hv_theme_light_ppt(bold = TRUE)
 
 # Via the generic dispatcher
 p + hv_theme("light_ppt")

--- a/man/save_ppt.Rd
+++ b/man/save_ppt.Rd
@@ -112,6 +112,61 @@ save_ppt(
   powerpoint   = "graphs/manuscript.pptx",
   slide_titles = "Fuel Economy"
 )
+
+# ----------------------------------------------------------------------
+# panel_box: anchor the plot panel to a fixed rectangle on every slide
+# ----------------------------------------------------------------------
+#
+# Problem: when plots in a deck have different y-axis ranges
+# (e.g. "1.0" vs "4567.2"), axis-label widths differ and shift the
+# panel inside a fixed ph_location(). On dark_ppt the black panel box
+# appears to drift between slides — visually jarring.
+#
+# Solution: pass `panel_box = list(width, height, left, top)`. This
+# describes the PANEL CONTENT AREA itself — the rectangle bounded by
+# the axis lines, not the outer plot extent. save_ppt() calls
+# [hv_ph_location()] for each plot, measures the axis / title / legend
+# chrome around the panel, and adjusts per-slide placement so the
+# panel lands at the target rectangle on every slide. The plot's
+# OUTER dimensions therefore vary per slide (chrome floats around a
+# constant panel), analogous to how [hv_ggsave_dims()] drives ggsave's
+# width/height from a target panel size.
+
+p_small <- ggplot(mtcars, aes(hp, mpg)) +
+  geom_point() +
+  scale_y_continuous(labels = function(x) sprintf("\%3.1f", x)) +
+  labs(x = "Horsepower", y = "MPG") +
+  hv_theme("dark_ppt")
+
+p_big <- ggplot(mtcars, aes(hp, mpg)) +
+  geom_point() +
+  scale_y_continuous(labels = function(x) sprintf("\%8.1f", x * 10000)) +
+  labs(x = "Horsepower", y = "MPG (x10k)") +
+  hv_theme("dark_ppt")
+
+# Without panel_box: panel drifts between slides because the big-number
+# labels eat more horizontal space than the small-number labels.
+save_ppt(
+  object       = list(p_small, p_big),
+  template     = "graphs/RD.pptx",
+  powerpoint   = "graphs/drifting_deck.pptx",
+  slide_titles = c("Small y-axis", "Big y-axis")
+)
+
+# With panel_box: target is a 10" x 5" panel at slide coordinates
+# (1.5", 1.5"). The panel content area lands at exactly that rectangle
+# on both slides; axis labels extend outside it as each plot requires.
+save_ppt(
+  object       = list(p_small, p_big),
+  template     = "graphs/RD.pptx",
+  powerpoint   = "graphs/anchored_deck.pptx",
+  slide_titles = c("Small y-axis", "Big y-axis"),
+  panel_box    = list(width = 10, height = 5, left = 1.5, top = 1.5)
+)
+
+# Sizing advice: panel_left and panel_top must be large enough for the
+# widest axis labels in the deck. If chrome spills off the slide edge,
+# hv_ph_location() emits a warning naming the offending edge.
 }
 
 }

--- a/man/save_ppt.Rd
+++ b/man/save_ppt.Rd
@@ -122,8 +122,8 @@ save_ppt(
 # panel inside a fixed ph_location(). On dark_ppt the black panel box
 # appears to drift between slides — visually jarring.
 #
-# Solution: pass `panel_box = list(width, height, left, top)`. This
-# describes the PANEL CONTENT AREA itself — the rectangle bounded by
+# Solution: pass `panel_box = list(width = ..., height = ..., left = ...,
+# top = ...)`. This describes the PANEL CONTENT AREA itself — the rectangle bounded by
 # the axis lines, not the outer plot extent. save_ppt() calls
 # [hv_ph_location()] for each plot, measures the axis / title / legend
 # chrome around the panel, and adjusts per-slide placement so the
@@ -165,8 +165,8 @@ save_ppt(
 )
 
 # Sizing advice: panel_left and panel_top must be large enough for the
-# widest axis labels in the deck. If chrome spills off the slide edge,
-# hv_ph_location() emits a warning naming the offending edge.
+# widest axis labels in the deck. If chrome extends past the left or top
+# slide edge, hv_ph_location() emits a warning naming that edge.
 }
 
 }

--- a/tests/testthat/test_themes.R
+++ b/tests/testthat/test_themes.R
@@ -191,6 +191,43 @@ test_that("theme_dark_ppt works with different ink colors", {
   expect_s3_class(theme_custom, "theme")
 })
 
+test_that("theme_dark_ppt hides legend by default", {
+  theme <- theme_dark_ppt()
+  expect_identical(theme$legend.position, "none")
+})
+
+test_that("theme_dark_ppt bold = TRUE sets face = 'bold' on axis elements", {
+  theme_bold  <- theme_dark_ppt(bold = TRUE)
+  theme_plain <- theme_dark_ppt(bold = FALSE)
+  expect_identical(theme_bold$axis.text$face,    "bold")
+  expect_identical(theme_bold$axis.title.x$face, "bold")
+  expect_identical(theme_bold$axis.title.y$face, "bold")
+  expect_identical(theme_plain$axis.text$face,   "plain")
+})
+
+test_that("theme_dark_ppt uses inside-facing ticks (negative length)", {
+  theme <- theme_dark_ppt(base_size = 32)
+  # Inside ticks: length should be negative, scaled via half_line = base_size/2
+  tlen <- grid::convertUnit(theme$axis.ticks.length, "pt", valueOnly = TRUE)
+  expect_lt(tlen, 0)                  # negative = inside
+  expect_equal(tlen, -32 / 4, tolerance = 1e-6)  # half_line / 2
+})
+
+test_that("theme_dark_ppt axis-title margins scale with base_size", {
+  t32 <- theme_dark_ppt(base_size = 32)
+  t16 <- theme_dark_ppt(base_size = 16)
+  m32 <- t32$axis.title.x$margin
+  m16 <- t16$axis.title.x$margin
+  # Margins should be 1.5 * half_line = 0.75 * base_size in pt — half at half the size
+  expect_equal(as.numeric(m32[1]), 2 * as.numeric(m16[1]), tolerance = 1e-6)
+})
+
+test_that("theme_light_ppt hides legend by default and accepts bold", {
+  theme <- theme_light_ppt()
+  expect_identical(theme$legend.position, "none")
+  expect_identical(theme_light_ppt(bold = TRUE)$axis.text$face, "bold")
+})
+
 # ============================================================================
 # theme_poster tests
 # ============================================================================

--- a/tests/testthat/test_themes.R
+++ b/tests/testthat/test_themes.R
@@ -228,6 +228,22 @@ test_that("theme_light_ppt hides legend by default and accepts bold", {
   expect_identical(theme_light_ppt(bold = TRUE)$axis.text$face, "bold")
 })
 
+test_that("theme_light_ppt uses inside-facing ticks (negative length)", {
+  theme <- theme_light_ppt(base_size = 32)
+  tlen <- grid::convertUnit(theme$axis.ticks.length, "pt", valueOnly = TRUE)
+  expect_lt(tlen, 0)                              # negative = inside
+  expect_equal(tlen, -32 / 4, tolerance = 1e-6)   # half_line / 2
+})
+
+test_that("theme_light_ppt axis-title margins scale with base_size", {
+  t32 <- theme_light_ppt(base_size = 32)
+  t16 <- theme_light_ppt(base_size = 16)
+  m32 <- t32$axis.title.x$margin
+  m16 <- t16$axis.title.x$margin
+  # Margins scale linearly with base_size (1.5 * half_line = 0.75 * base_size in pt)
+  expect_equal(as.numeric(m32[1]), 2 * as.numeric(m16[1]), tolerance = 1e-6)
+})
+
 # ============================================================================
 # theme_poster tests
 # ============================================================================


### PR DESCRIPTION
## Summary

Folds the hand-rolled AATS theme conventions from internal presentation scripts into `hv_theme_dark_ppt()` and `hv_theme_light_ppt()` (parity) so users can drop their custom `theme_update()` block entirely. Combined with v2.0.0.9012's `save_ppt(panel_box = ...)`, the `family = "mono"` y-axis workaround for panel drift is no longer needed.

**Intended as the last feature before the v2.0.0 tag** — next PR after this lands is engineering → main with the 2.0.0 version bump + `v2.0.0` tag.

## Changes to default PPT theme behavior

| Aspect | Before | After |
|---|---|---|
| Legend | shown (ggplot default) | **hidden** (`legend.position = "none"`) |
| Axis ticks | outside-facing, default length | **inside-facing**, `-half_line/2 pt` |
| Axis-text margin | ggplot default (~6pt at base_size 32) | `half_line` (16pt @ base_size 32) |
| Axis-title margin | ggplot default (~8pt at base_size 32) | `1.5 × half_line` (24pt @ base_size 32) |

All new margin values are **scaled from `base_size` via ggplot2's `half_line = base_size / 2` convention** — no hardcoded `cm` values. Spacing stays proportional as `base_size` changes.

## New option

- `bold = FALSE` argument on both themes; `bold = TRUE` applies `face = "bold"` to axis text + axis titles. Default preserves the prior appearance.

## Intentionally NOT changed (per design discussion)

- **Font family** — left as device default (no forced Arial)
- **Strip labels** — still shown; caller hides via `theme()` when doing annotated-panel presentations
- **mono y-axis workaround** — dropped; `save_ppt(panel_box = ...)` solved the drift problem

## Tests

- +6 new tests covering: legend-hidden default, `bold` toggle on dark/light, inside-tick length computation, `half_line` margin scaling, light_ppt parity
- Full suite: **1068 PASS, 0 FAIL**
- R CMD check: 0 errors, 0 warnings (one transient network NOTE "unable to verify current time" — not code-related)

## Migration note for callers of `hv_theme_*_ppt()`

Callers that relied on the default legend being shown need to add `+ theme(legend.position = "right")` (or similar). Listed in NEWS as a behaviour change.