### PR TITLE
bump to 2.0.1.9000 — start next dev cycle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hvtiPlotR
 Type: Package
 Title: Porting HVTI plot templates and methodology documentation to ggplot2 package in R
-Version: 2.0.0
+Version: 2.0.1.9000
 Date: 2026-04-21
 Authors@R: c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hvtiPlotR 2.0.1.9000
+
+Development version — no user-visible changes yet.
+
 # hvtiPlotR 2.0.0
 
 First stable release of the `hv_*` API. This consolidates the


### PR DESCRIPTION
Starts the next development cycle after the v2.0.0 tag. No user-visible changes.