### PR TITLE
release: hvtiPlotR 2.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hvtiPlotR
 Type: Package
 Title: Porting HVTI plot templates and methodology documentation to ggplot2 package in R
-Version: 2.1.0
-Date: 2026-04-27
+Version: 2.2.0
+Date: 2026-05-11
 Authors@R: c(
     person(
       "John", "Ehrlinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hvtiPlotR 2.2.0 (in development)
+# hvtiPlotR 2.2.0
 
 ## New S3 methods for `hv_data` objects (#64)
 


### PR DESCRIPTION
## Summary

Bumps `DESCRIPTION` to **2.2.0** (dated 2026-05-11) and finalises the `# hvtiPlotR 2.2.0` NEWS header (drops the `(in development)` suffix).

The substantive changes were merged in two prior PRs:

- **[#63](https://github.com/ehrlinger/hvtiPlotR/pull/63)** — replace ComplexUpset with ggupset (closes #62). The intersection-bar plot is now a standard ggplot, so `ggplot_build()` works on the output, the Windows CI gate is gone, and there's no more theme-API deprecation noise. **Breaking:** removed `base_annotations`; `min_size` → `n_intersections`; themes apply via `&` on the default patchwork composite or `+` when `set_size = FALSE`.
- **[#65](https://github.com/ehrlinger/hvtiPlotR/pull/65)** — three additive S3 methods on `hv_data` (closes #64): `summary()`, `autoplot()` (with ggplot2's generic re-exported from the hvtiPlotR namespace), and `as.data.frame()`. No breaking changes.

## Test plan

- [ ] CI: R-CMD-check, lint, pkgdown, test-coverage, full OS matrix
- [ ] After merge: tag `v2.2.0` on the merge commit + publish GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)