### PR TITLE
release: hvtiPlotR 2.3.1 — documentation voice audit

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -40,3 +40,4 @@ hvtiPlotR.Rproj
 ^testing-strategy\.md$
 ^.*\.fuse_hidden
 ^\.positai$
+^writing-voice\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hvtiPlotR
 Type: Package
-Title: Porting HVTI plot templates and methodology documentation to ggplot2 package in R
+Title: HVTI ggplot2 themes and clinical plot functions for the Cleveland Clinic Heart & Vascular Institute
 Version: 2.3.0
 Date: 2026-05-21
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hvtiPlotR
 Type: Package
 Title: HVTI ggplot2 themes and clinical plot functions for the Cleveland Clinic Heart & Vascular Institute
-Version: 2.3.0
-Date: 2026-05-21
+Version: 2.3.1
+Date: 2026-05-22
 Authors@R: c(
     person(
       "John", "Ehrlinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# hvtiPlotR 2.3.1
+
+## Documentation (#69)
+
+- Package-wide voice rewrite of every prose surface — README, vignettes,
+  NEWS, slide deck, roxygen, DESCRIPTION `Title:` — against the
+  `writing-voice.md` spec. Prose only; no API or behavioural change.
+- Fixed stale `hv_theme()` string-key references (`"dark_ppt"`, `"ppt"`,
+  `"light_ppt"`, `"manuscript"`, `"poster"`) in the main tutorial and
+  SAS-migration vignettes. That dispatcher was removed in 2.1.0; the
+  vignettes now name the actual `theme_hv_*()` functions.
+- Fixed missing "to" in the main tutorial's introduction
+  ("is simplify" → "is to simplify").
+- README now lists all five vignettes (`sas-migration-guide` was
+  missing) and the "Migrating from plot.sas" section points at the
+  dedicated migration vignette.
+- Synced a copy of `writing-voice.md` into the repo root for future
+  documentation work.
+
 # hvtiPlotR 2.3.0
 
 ## CONSORT patient flow tracking and diagram (#67)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,22 +2,19 @@
 
 ## CONSORT patient flow tracking and diagram (#67)
 
-New two-class API for building auditable CONSORT flow diagrams from
-patient-level data.
+Two-class API for CONSORT flow diagrams built from patient-level data.
 
 **Tracker lifecycle:**
 
 - `hv_consort_start(data, patient_id, label, pass_col)` — initialises a
-  tracker with one row per patient and a boolean column marking all patients
-  as screened.
+  tracker with one row per patient; all patients begin as screened.
 - `hv_consort_exclude(tracker, label, col, ..., excl_label, pass_col)` —
   adds an exclusion stage via formula rules (`condition ~ "Reason string"`).
   First-matching formula wins; gating on the prior stage is automatic.
-  Pipe-friendly.
 - `hv_consort_summary(tracker)` — returns a data frame with N included
   and N excluded per stage; suitable for methods-section tables.
 - `hv_consort_patients(tracker, stage, reason)` — returns patient IDs at
-  any stage, or the subset excluded for a specific reason, for full auditability.
+  any stage, or the subset excluded for a specific reason.
 
 **Diagram:**
 
@@ -55,26 +52,23 @@ subclass:
 
 - **`summary()`** — prints the standard one-screen header, then walks
   the object's `$tables` slot and prints each named auxiliary table
-  with a header. Lets callers see the underlying risk tables, report
-  tables, and diagnostics without having to know the `$tables`
-  accessor path. Subclasses can override with a curated layout.
+  with a header. Callers get risk tables, report tables, and diagnostics
+  without reaching for `$tables` directly. Subclasses can override with
+  a curated layout.
 - **`autoplot()`** — re-exports ggplot2's `autoplot()` generic and
   dispatches to the registered `plot.<subclass>()` method. Callers who
-  prefer the ggplot2-ecosystem verb (used by `broom`, `ggfortify`,
-  `ggsurvfit`) can write `autoplot(km)` interchangeably with
+  prefer the ggplot2-ecosystem verb can write `autoplot(km)` in place of
   `plot(km)`. Extra args forward to the subclass `plot()`.
-- **`as.data.frame()`** — returns the `$data` slot. Lets callers use
-  the standard `as.data.frame()` / `data.frame()` coercion in
-  tidyverse pipelines instead of reaching for the `$data` accessor.
+- **`as.data.frame()`** — returns the `$data` slot via standard
+  `as.data.frame()` coercion instead of the `$data` accessor.
 
-No breaking changes — these are additive.
+No breaking changes.
 
 ## UpSet plot backend swap (#62)
 
 `plot.hv_upset()` is now backed by [`ggupset`](https://cran.r-project.org/package=ggupset)
-rather than `ComplexUpset`. The intersection-size bar chart is a standard
-ggplot — themes apply via `+` like every other hvtiPlotR plot, and
-`ggplot2::ggplot_build()` works on the output. When `set_size = TRUE`
+rather than `ComplexUpset`. The intersection-size bar chart is a standard ggplot; themes apply via
+`+`, and `ggplot2::ggplot_build()` works on the output. When `set_size = TRUE`
 (the default) a manual set-size sidebar is composed via `patchwork`.
 
 **Breaking changes:**
@@ -114,7 +108,7 @@ ggplot — themes apply via `+` like every other hvtiPlotR plot, and
   matching ggplot2's `theme_bw()` / `theme_grey()` naming.
 - Each theme follows the `theme_bw()` contract: pass `base_size` /
   `base_family` to control typography, then forward any extra named
-  theme element through `...` to override inline. Examples:
+  theme element through `...` to override. Examples:
   ```r
   theme_hv_manuscript(legend.position = "right")
   theme_hv_ppt_dark(axis.text.y = element_text(family = "mono"))
@@ -165,7 +159,7 @@ ggplot — themes apply via `+` like every other hvtiPlotR plot, and
 
 ## Documentation
 
-- Package-level help topic (`?hvtiPlotR`) comprehensively rewritten to
+- Package-level help topic (`?hvtiPlotR`) rewritten to
   cover the v2.0.0 feature set: two-step workflow with runnable
   example, fixed-panel geometry subsection
   (`hv_ggsave_dims()`/`hv_ph_location()`/`save_ppt(panel_box=)`),
@@ -194,13 +188,13 @@ directly; no `.9xxx` pre-release suffixes.
 ## New features — fixed-panel geometry
 
 The dominant theme of this release is making the **panel content area**
-(the rectangular data region, excluding axes/titles/legend/margins) a
-first-class target, so figures stay visually aligned across output
+(the rectangular data region, excluding axes/titles/legend/margins)
+directly addressable, so figures stay visually aligned across output
 devices and across slides in a deck even when axis-label widths differ.
 
 - `hv_ggsave_dims(plot, width, height, units = "in")`: compute
   `ggsave()` `width`/`height` that preserve a fixed panel content area
-  regardless of axis labels, legend, title, or facet strips. Returns a
+  regardless of surrounding chrome. Returns a
   named list shaped to splat into `ggsave()` via
   `do.call(ggsave, c(list(filename = ..., plot = p), dims))`. Units are
   length-only (`"in"`, `"cm"`, `"mm"`) since the sizing device is PDF.
@@ -215,10 +209,10 @@ devices and across slides in a deck even when axis-label widths differ.
 - `save_ppt(..., panel_box = list(width, height, left, top))`: new
   optional argument. When supplied, per-slide placement is computed via
   `hv_ph_location()` so every slide anchors the panel at the given
-  rectangle — solving the "plot background box moves between slides"
-  problem on dark PPT themes where the panel is visibly filled. When
-  `panel_box = NULL` (default), the fixed `width`/`height`/`left`/`top`
-  arguments are used (legacy behavior).
+  rectangle; on dark PPT themes where the panel fill is visible, the
+  panel no longer shifts between slides. When `panel_box = NULL`
+  (default), the fixed `width`/`height`/`left`/`top` arguments are used
+  (legacy behavior).
 
 ## New features — PPT theme polish
 
@@ -289,7 +283,7 @@ devices and across slides in a deck even when axis-label widths differ.
     `y = Inf`/`y = -Inf` plus `vjust`, anchoring each group label near the
     top/bottom panel edge regardless of dataset size.
   - Replaced hard-coded label strings (`"SAVR"`, `"TF-TAVR"`, etc.) with
-    `mh$meta$group_labels[1]` / `[2]`, so the annotations always track the
+    `mh$meta$group_labels[1]` / `[2]`, so the annotations track the
     labels supplied to the constructor.
 
 # hvtiPlotR 2.0.0.9008
@@ -399,8 +393,8 @@ devices and across slides in a deck even when axis-label widths differ.
 ## Documentation
 
 - All `hv_*` constructors and `plot.hv_*` methods now carry `@family`
-  tags, creating automatic bi-directional "See also" cross-links between each
-  constructor and its plot method in the help system and pkgdown reference.
+  tags; the help system and pkgdown reference both show bi-directional
+  "See also" links between each constructor and its plot method.
 - `@return` on every constructor now explicitly says "call `plot()` to render"
   and links to the corresponding `plot.hv_*` method.
 - `@seealso` entries across all constructors and plot methods now include
@@ -613,16 +607,15 @@ on `plot()`:
   `spaghetti-plot.R`, `stacked-histogram.R`, `trends-plot.R`, and
   `upset-plot.R` now delegate `data.frame`, column-presence, numeric-column,
   and alpha checks to `.check_df()`, `.check_cols()`, `.check_col()`,
-  `.check_numeric_col()`, and `.check_alpha()`. Error wording is now
-  consistent across all entry points.
+  `.check_numeric_col()`, and `.check_alpha()`. Error messages use consistent
+  wording across all entry points.
 
 ## Code quality
 
 * Named all simulation tuning constants in `sample_nonparametric_curve_data()`
   and the internal helper `.np_sample_bins()`: `eta_intercept`, `logit_shift`,
   `cont_baseline`, `cont_scale`, `cont_sigma`, `eff_frac_prob`,
-  `eff_frac_cont`. Magic numbers replaced throughout single-curve,
-  multi-group, and binned-data-summary code paths.
+  `eff_frac_cont`. Magic numbers replaced throughout.
 * Named all simulation tuning constants in `sample_nonparametric_ordinal_data()`
   and `sample_nonparametric_ordinal_points()`: `a_first`, `a_step`,
   `eta_intercept`. Every occurrence of `-0.2`, `0.5`, and `1.2` replaced by

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,8 +57,9 @@ subclass:
   a curated layout.
 - **`autoplot()`** — re-exports ggplot2's `autoplot()` generic and
   dispatches to the registered `plot.<subclass>()` method. Callers who
-  prefer the ggplot2-ecosystem verb can write `autoplot(km)` in place of
-  `plot(km)`. Extra args forward to the subclass `plot()`.
+  prefer the ggplot2-ecosystem verb (`broom`, `ggfortify`, and `ggsurvfit`
+  all use it) can write `autoplot(km)` in place of `plot(km)`. Extra args
+  forward to the subclass `plot()`.
 - **`as.data.frame()`** — returns the `$data` slot via standard
   `as.data.frame()` coercion instead of the `$data` accessor.
 
@@ -615,7 +616,8 @@ on `plot()`:
 * Named all simulation tuning constants in `sample_nonparametric_curve_data()`
   and the internal helper `.np_sample_bins()`: `eta_intercept`, `logit_shift`,
   `cont_baseline`, `cont_scale`, `cont_sigma`, `eff_frac_prob`,
-  `eff_frac_cont`. Magic numbers replaced throughout.
+  `eff_frac_cont`. Magic numbers replaced throughout the single-curve,
+  multi-group, and binned-data-summary code paths.
 * Named all simulation tuning constants in `sample_nonparametric_ordinal_data()`
   and `sample_nonparametric_ordinal_points()`: `a_first`, `a_step`,
   `eta_intercept`. Every occurrence of `-0.2`, `0.5`, and `1.2` replaced by

--- a/R/alluvial-plot.R
+++ b/R/alluvial-plot.R
@@ -210,7 +210,7 @@ print.hv_alluvial <- function(x, ...) {
 #' @param flow_width    Width of the alluvium flows. Default \code{1/6}.
 #' @param alpha         Transparency of the flows, \eqn{[0,1]}. Default \code{0.8}.
 #' @param knot_pos      Curvature of the flow ribbons, \eqn{[0,1]}. Default \code{0.4}.
-#' @param show_labels   Logical; whether to label each stratum. Default \code{TRUE}.
+#' @param show_labels   Logical; if TRUE, each stratum is labelled. Default \code{TRUE}.
 #' @param ...           Ignored; present for S3 consistency.
 #'
 #' @return A bare \code{\link[ggplot2]{ggplot}} object.

--- a/R/covariate-balance.R
+++ b/R/covariate-balance.R
@@ -282,10 +282,10 @@ plot.hv_balance <- function(x,
 #' extremes cannot be matched, leaving small residual differences for the
 #' strongest confounders.
 #'
-#' @param n_vars Integer. Number of covariates to generate. Default `12`.
-#' @param n Integer. Total number of simulated patients before matching.
+#' @param n_vars Integer; number of covariates to generate. Default `12`.
+#' @param n Integer; total number of simulated patients before matching.
 #'   Default `600` (roughly 300 per group at `separation = 1.5`).
-#' @param separation Numeric. Distance between the two group means on the
+#' @param separation Numeric; distance between the two group means on the
 #'   log-odds scale.  Larger values push propensity score distributions
 #'   further apart, increasing the proportion of unmatched extreme-score
 #'   patients and residual imbalance after matching.  Default `1.5`.

--- a/R/goodness-followup.R
+++ b/R/goodness-followup.R
@@ -176,7 +176,7 @@ sample_goodness_followup_data <- function(
 #'   \code{as.Date("2019-12-31")}.
 #' @param close_date         Data close date.  Must be \eqn{\geq}
 #'   \code{study_end}.  Default \code{as.Date("2021-08-06")}.
-#' @param tolower_names      Logical; whether to lower-case column names when
+#' @param tolower_names      Logical; if TRUE, column names are lower-cased when
 #'   materialising the data.  Default \code{TRUE}.
 #' @param death_levels       Length-2 character vector labelling the two death
 #'   states (alive first).  Default \code{c("Alive", "Dead")}.

--- a/R/hazard-plot.R
+++ b/R/hazard-plot.R
@@ -479,7 +479,7 @@ sample_nnt_data <- function(n        = 500,
 #' plus [plot.hv_hazard()].
 #'
 #' Pass your `predict` dataset from a Weibull (or other parametric) model and
-#' get back a ggplot of the survival, hazard, or cumulative-hazard curve — with
+#' get back a ggplot of the survival, hazard, or cumulative-hazard curve, with
 #' optional KM empirical overlay and population life-table reference. Covers
 #' the full `tp.hp.dead.*` SAS template family.
 #'

--- a/R/hazard-plot.R
+++ b/R/hazard-plot.R
@@ -478,10 +478,10 @@ sample_nnt_data <- function(n        = 500,
 #' `hazard_plot()` has been superseded by the S3 constructor [hv_hazard()]
 #' plus [plot.hv_hazard()].
 #'
-#' Plots a pre-computed parametric survival, hazard, or cumulative-hazard curve
-#' from a Weibull (or other parametric) model, optionally overlaid with
-#' Kaplan-Meier empirical estimates and a population life-table reference.
-#' Covers the complete family of `tp.hp.dead.*` SAS templates.
+#' Pass your `predict` dataset from a Weibull (or other parametric) model and
+#' get back a ggplot of the survival, hazard, or cumulative-hazard curve — with
+#' optional KM empirical overlay and population life-table reference. Covers
+#' the full `tp.hp.dead.*` SAS template family.
 #'
 #' | SAS template | R usage |
 #' |---|---|
@@ -1011,7 +1011,7 @@ hazard_plot <- function(curve_data,
 #' `survival_difference_plot()` has been superseded by the S3 constructor
 #' [hv_survival_difference()] plus [plot.hv_survival_difference()].
 #'
-#' Plots the difference in survival between two groups over time, with an
+#' Pass a `diffout` dataset and you get the S_2(t) - S_1(t) curve with an
 #' optional confidence band. Covers `tp.hp.dead.life-gained.sas` and the
 #' survival-difference component of `tp.hp.numtreat.survdiff.matched.sas`.
 #'
@@ -1148,9 +1148,9 @@ survival_difference_plot <- function(diff_data,
 #' `nnt_plot()` has been superseded by the S3 constructor [hv_nnt()] plus
 #' [plot.hv_nnt()].
 #'
-#' Plots the number needed to treat (NNT) and/or absolute risk reduction (ARR)
-#' over time, with optional confidence bands. Covers the NNT component of
-#' `tp.hp.numtreat.survdiff.matched.sas`.
+#' Pass the `nntout` dataset and plot NNT (or ARR) over time. Add
+#' `lower_col`/`upper_col` for a confidence band. Covers the NNT component
+#' of `tp.hp.numtreat.survdiff.matched.sas`.
 #'
 #' **SAS context:** The SAS template computes NNT at discrete time points
 #' (1, 5, 10, 15, 20 years) from the HAZDIFL macro output, then connects them

--- a/R/help.R
+++ b/R/help.R
@@ -7,9 +7,9 @@
 #' `hvtiPlotR` is an R port of the `plot.sas` macro suite used by the
 #' Cardiovascular Outcomes, Registries and Research (CORR) statistics
 #' group within the Heart, Vascular and Thoracic Institute at the
-#' Cleveland Clinic. It produces publication-quality graphics that
-#' conform to HVTI manuscript, poster, and presentation standards using
-#' `ggplot2` and the `officer` package.
+#' Cleveland Clinic. We use it to produce graphics that meet HVTI
+#' manuscript, poster, and presentation standards, built on `ggplot2`
+#' and the `officer` package.
 #'
 #' @details
 #' ## Two-step workflow
@@ -22,7 +22,8 @@
 #' 2. Call `plot()` on the object to obtain a bare `ggplot2::ggplot`
 #'    you can decorate with scales, labels, annotations, and themes
 #'    without restriction.
-#' 3. Call `print()` on the object for a concise console summary.
+#'
+#' Calling `print()` on the object gives a concise console summary.
 #'
 #' ```
 #' library(ggplot2)
@@ -207,9 +208,6 @@
 #'
 #' ## Sample-data generators
 #'
-#' Each generator produces realistic synthetic data sized and structured
-#' to match the corresponding SAS dataset exports.
-#'
 #' * [sample_mirror_histogram_data()]: Propensity scores via a logistic
 #'   model with greedy 1:1 caliper matching and optional IPTW weights.
 #' * [sample_covariate_balance_data()]: Standardised mean differences
@@ -256,8 +254,8 @@
 #' ## Scope and versioning
 #'
 #' `hvtiPlotR` targets **internal HVTI / CORR use only** — it will not
-#' be submitted to CRAN. GitHub-only dependencies are first-class
-#' (`Remotes:` in DESCRIPTION). Install via:
+#' be submitted to CRAN. GitHub-only dependencies are declared in
+#' `Remotes:` in DESCRIPTION and install cleanly. Install via:
 #'
 #' ```
 #' remotes::install_github("ehrlinger/hvtiPlotR")

--- a/R/mirror-histogram.R
+++ b/R/mirror-histogram.R
@@ -566,7 +566,7 @@ plot.hv_mirror_hist <- function(x, alpha = 0.8, ...) {
 #' reproduces the "many unmatched at the tails" pattern seen in real studies.
 #'
 #' @param n Number of observations **per group** (default 500).
-#' @param separation Numeric. Distance between the two group means on the
+#' @param separation Numeric; distance between the two group means on the
 #'   log-odds scale.  Larger values push the score distributions further apart
 #'   and increase the proportion of unmatched patients at the extremes
 #'   (default 1.5).

--- a/R/pdf_footnote.R
+++ b/R/pdf_footnote.R
@@ -26,12 +26,10 @@
 #' ggsave("figures/fig1.pdf", p, width = 11, height = 8.5)
 #' ```
 #'
-#' @param text     Text to display. Defaults to the current working directory,
-#'   which conveniently identifies the project. For the typical use case pass
-#'   the script filename: `make_footnote("R/analysis.R")`.
-#' @param timestamp Logical; append `Sys.time()` to `text`? Default `TRUE`.
-#'   Set to `FALSE` for reproducible screenshots or when the file path already
-#'   contains enough context.
+#' @param text     Text to display. Defaults to the current working directory;
+#'   for most uses pass the script filename instead: `make_footnote("R/analysis.R")`.
+#' @param timestamp Logical; if TRUE, `Sys.time()` is appended to `text`. Default `TRUE`.
+#'   Set to `FALSE` for reproducible output.
 #' @param prefix   String prepended to `text` before the timestamp. Default
 #'   `"DRAFT \u2014 "`. Set to `""` to suppress the prefix.
 #' @param size     Font size as a multiplier relative to the device default

--- a/R/stacked-histogram.R
+++ b/R/stacked-histogram.R
@@ -176,11 +176,11 @@ plot.hv_stacked <- function(x, ...) {
 #' Creates a minimal data frame suitable for demonstrating or testing
 #' \code{\link{hv_stacked}}.
 #'
-#' @param n_years      Integer. Number of consecutive years to simulate starting
+#' @param n_years      Integer; number of consecutive years to simulate starting
 #'   from \code{start_year}. Defaults to `20`.
-#' @param start_year   Integer. First calendar year in the sequence. Defaults to
+#' @param start_year   Integer; first calendar year in the sequence. Defaults to
 #'   `2000`.
-#' @param n_categories Integer. Number of distinct groups. Defaults to `3`.
+#' @param n_categories Integer; number of distinct groups. Defaults to `3`.
 #' @param seed         Integer passed to \code{\link[base]{set.seed}} for
 #'   reproducibility. Defaults to `42`.
 #'

--- a/R/themes.R
+++ b/R/themes.R
@@ -11,16 +11,16 @@
 #'
 #' Each theme follows the `theme_bw()` contract: pass `base_size` /
 #' `base_family` to control global typography, then chain a `+ theme(...)`
-#' call to override anything else. Additionally, any extra named argument is
-#' forwarded straight into a final [ggplot2::theme()] call so callers can
-#' tweak elements inline:
+#' call to override anything else. Any extra named argument goes straight
+#' into a final [ggplot2::theme()] call; tweak elements at the call site
+#' without a separate `+` chain:
 #'
 #' ```
 #' theme_hv_manuscript(legend.position = "right")
 #' theme_hv_ppt_dark(axis.text.y = element_text(family = "mono"))
 #' ```
 #'
-#' Caller-supplied elements override the hvtiPlotR defaults.
+#' Your elements override the hvtiPlotR defaults.
 #'
 #' @param base_size      Base font size in points.
 #' @param base_family    Base font family. Default `""` (device default).
@@ -143,12 +143,13 @@ theme_hv_poster <- function(base_size      = 16,
 #' @details
 #' `theme_hv_ppt_dark()` is the default PPT theme: a black panel with white
 #' text suited to dark slide backgrounds. Use [theme_hv_ppt_light()] when the
-#' slide template is light. Both PPT themes hide the legend by default --
+#' slide template is light. Both PPT themes hide the legend by default;
 #' override with `legend.position = "right"` (or chain `+ theme(...)`).
 #'
 #' Margins on axis text/title are scaled from `base_size` via the standard
-#' `half_line = base_size / 2` convention, so spacing stays proportional when
-#' `base_size` changes.
+#' `half_line = base_size / 2` convention; a deck at `base_size = 28` and
+#' one at `base_size = 36` both feel proportionate without you touching
+#' the margins.
 #' @export
 theme_hv_ppt_dark <- function(base_size      = 32,
                               base_family    = "",

--- a/R/upset-plot.R
+++ b/R/upset-plot.R
@@ -214,7 +214,7 @@ print.hv_upset <- function(x, ...) {
 #'   `"steelblue"`.
 #' @param width_ratio         Fraction of horizontal space given to the
 #'   set-size sidebar (only used when `set_size = TRUE`). Default `0.3`.
-#' @param ...                 Currently unused; reserved for future args.
+#' @param ...                 Ignored; present for S3 consistency.
 #'
 #' @return A `ggplot` when `set_size = FALSE` (themes apply with `+`); a
 #'   `patchwork` composite when `set_size = TRUE` (default; themes apply

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11780.svg)](https://doi.org/10.5281/zenodo.11780)
 <!-- badges: end -->
 
-ggplot2 themes and plot functions for creating publication-quality graphics in R, conforming to the standards of Cardiovascular Outcomes Registries and Research (CORR) within The Heart & Vascular Institute at the Cleveland Clinic. This package is the modern R replacement for the historical `plot.sas` macro.
+hvtiPlotR packages the ggplot2 themes and plot functions we use in Cardiovascular Outcomes Registries and Research (CORR) at the Cleveland Clinic Heart & Vascular Institute. If you are migrating from the `plot.sas` macro, this is its R successor.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Install from GitHub using [remotes](https://CRAN.R-project.org/package=remotes):
 remotes::install_github("ehrlinger/hvtiPlotR")
 ```
 
-Apply an HVI theme to any ggplot2 figure in one line:
+Apply an HVI theme to a ggplot2 figure in one line:
 
 ```r
 library(ggplot2)
@@ -131,7 +131,7 @@ plot(mh) + hv_theme("manuscript")
 
 ## Vignettes
 
-Four vignettes ship with the package and are available after installation:
+Four vignettes ship with the package. After installation, call any of them from the R console:
 
 ```r
 vignette("hvtiPlotR",        package = "hvtiPlotR")  # SAS migration guide
@@ -144,21 +144,19 @@ The online reference is at <https://ehrlinger.github.io/hvtiPlotR/>.
 
 ## Slides
 
-A short PowerPoint presentation covering the v2.x redesign — the two-step S3 API,
-the renamed theme functions, and `save_ppt(panel_box =)` — ships with the package
+A short PowerPoint presentation covering the v2.x redesign (the two-step S3 API,
+renamed theme functions, and `save_ppt(panel_box =)`) ships with the package
 as a Quarto source file:
 
 ```r
 system.file("slides/hvtiPlotR-whats-new.qmd", package = "hvtiPlotR")
 ```
 
-Render it to `.pptx` with `quarto render` or `quarto::quarto_render()`. The slide
-content is a condensed version of the detail found in `vignette("plot-decorators")`
-and `vignette("hvtiPlotR")`.
+Render it to `.pptx` with `quarto render` or `quarto::quarto_render()`. The slides condense what you will find in `vignette("plot-decorators")` and `vignette("hvtiPlotR")`.
 
 ## Migrating from plot.sas
 
-If you are moving existing SAS analyses to R, see the SAS migration vignette (`vignette("hvtiPlotR")`). It maps each `plot.sas` macro call to the equivalent R recipe and shows side-by-side code comparisons.
+If you are moving existing SAS analyses to R, the SAS migration vignette (`vignette("hvtiPlotR")`) maps each `plot.sas` macro call to its R equivalent.
 
 The `inst/plot.README` and `inst/plot.sas` files are preserved for historical reference.
 
@@ -186,4 +184,4 @@ requests.
 
 ## Code of Conduct
 
-This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). By participating, you are expected to uphold this code.
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) code of conduct.

--- a/README.md
+++ b/README.md
@@ -131,13 +131,14 @@ plot(mh) + hv_theme("manuscript")
 
 ## Vignettes
 
-Four vignettes ship with the package. After installation, call any of them from the R console:
+Five vignettes ship with the package. After installation, call any of them from the R console:
 
 ```r
-vignette("hvtiPlotR",        package = "hvtiPlotR")  # SAS migration guide
-vignette("plot-functions",   package = "hvtiPlotR")  # per-function reference with worked examples
-vignette("plot-decorators",  package = "hvtiPlotR")  # composition: scale_*, labs(), themes, saving
-vignette("contributing",     package = "hvtiPlotR")  # guide for adding new plot functions
+vignette("hvtiPlotR",           package = "hvtiPlotR")  # package tutorial: generating plot.sas-style figures in R
+vignette("sas-migration-guide", package = "hvtiPlotR")  # SAS template -> hvtiPlotR migration mapping
+vignette("plot-functions",      package = "hvtiPlotR")  # per-function reference with worked examples
+vignette("plot-decorators",     package = "hvtiPlotR")  # composition: scale_*, labs(), themes, saving
+vignette("contributing",        package = "hvtiPlotR")  # guide for adding new plot functions
 ```
 
 The online reference is at <https://ehrlinger.github.io/hvtiPlotR/>.
@@ -156,7 +157,7 @@ Render it to `.pptx` with `quarto render` or `quarto::quarto_render()`. The slid
 
 ## Migrating from plot.sas
 
-If you are moving existing SAS analyses to R, the SAS migration vignette (`vignette("hvtiPlotR")`) maps each `plot.sas` macro call to its R equivalent.
+If you are moving existing SAS analyses to R, the SAS migration vignette (`vignette("sas-migration-guide")`) maps each `plot.sas` macro call to its R equivalent.
 
 The `inst/plot.README` and `inst/plot.sas` files are preserved for historical reference.
 

--- a/inst/slides/hvtiPlotR-whats-new.qmd
+++ b/inst/slides/hvtiPlotR-whats-new.qmd
@@ -50,7 +50,7 @@ format:
 
 ## The Two-Step Workflow
 
-Every plot function now follows the same two-step pattern:
+You now build every plot in two steps:
 
 ```r
 # Step 1: construct & validate
@@ -71,8 +71,8 @@ plot(km) +
   theme_hv_manuscript()
 ```
 
-Validation and rendering are fully separated. You can inspect, subset, or
-re-use `km$tables` before ever calling `plot()`.
+Validation and rendering are separated — inspect, subset, or re-use
+`km$tables` before you ever call `plot()`.
 
 ## Before & After: Constructors
 
@@ -155,7 +155,7 @@ plot(km) + theme_hv_ppt_dark()
 
 ## New S3 Convenience Methods (v2.2)
 
-Three standard R verbs are now available on every `hv_data` object:
+Every `hv_data` object now speaks standard R:
 
 ```r
 km <- hv_survival(my_data, "time", "event")
@@ -170,8 +170,8 @@ autoplot(km) + theme_hv_manuscript()
 df <- as.data.frame(km)   # same as km$data
 ```
 
-`autoplot()` is interchangeable with `plot()` — useful when working
-with packages like `broom` or `ggfortify` that prefer the ggplot2 verb.
+`autoplot()` is an alias for `plot()` — handy if you're in a `broom` or
+`ggfortify` pipeline that expects the ggplot2 verb.
 
 # Themes
 
@@ -242,7 +242,7 @@ ggplot2::theme_set(theme_hv_manuscript())
 ```
 
 Every `...` argument is forwarded directly to `ggplot2::theme()`,
-so any valid theme element works — no package-specific wrappers needed.
+so anything valid there works here too.
 
 → **Full reference:** [vignette("plot-decorators")](https://ehrlinger.github.io/hvtiPlotR/articles/plot-decorators.html)
 
@@ -311,8 +311,8 @@ save_ppt(
 axis chrome and adjusting the overall plot placement so the **panel lands
 at the same slide coordinates on every slide**.
 
-**Workflow tip:** develop with `theme_hv_ppt_light()` so the white panel is
-visible in your IDE viewer; save into your dark template at export time.
+Develop with `theme_hv_ppt_light()` so the white panel is visible in your
+IDE viewer; save into your dark template at export time.
 
 → **Full reference:** [vignette("plot-decorators")](https://ehrlinger.github.io/hvtiPlotR/articles/plot-decorators.html)
 

--- a/inst/slides/hvtiPlotR-whats-new.qmd
+++ b/inst/slides/hvtiPlotR-whats-new.qmd
@@ -6,7 +6,7 @@ date: today
 format:
   revealjs:
     slide-level: 2
-    theme: solarized
+    theme: default
     slide-number: true
     progress: true
     embed-resources: true

--- a/man/hazard_plot.Rd
+++ b/man/hazard_plot.Rd
@@ -110,10 +110,10 @@ A \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 \code{hazard_plot()} has been superseded by the S3 constructor \code{\link[=hv_hazard]{hv_hazard()}}
 plus \code{\link[=plot.hv_hazard]{plot.hv_hazard()}}.
 
-Plots a pre-computed parametric survival, hazard, or cumulative-hazard curve
-from a Weibull (or other parametric) model, optionally overlaid with
-Kaplan-Meier empirical estimates and a population life-table reference.
-Covers the complete family of \verb{tp.hp.dead.*} SAS templates.\tabular{ll}{
+Pass your \code{predict} dataset from a Weibull (or other parametric) model and
+get back a ggplot of the survival, hazard, or cumulative-hazard curve — with
+optional KM empirical overlay and population life-table reference. Covers
+the full \verb{tp.hp.dead.*} SAS template family.\tabular{ll}{
    SAS template \tab R usage \cr
    Basic survival (tp.hp.dead.sas) \tab \code{hazard_plot(dat, estimate_col="survival")} \cr
    Basic hazard (tp.hp.dead.sas) \tab \code{hazard_plot(dat, estimate_col="hazard")} \cr

--- a/man/hazard_plot.Rd
+++ b/man/hazard_plot.Rd
@@ -111,7 +111,7 @@ A \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 plus \code{\link[=plot.hv_hazard]{plot.hv_hazard()}}.
 
 Pass your \code{predict} dataset from a Weibull (or other parametric) model and
-get back a ggplot of the survival, hazard, or cumulative-hazard curve — with
+get back a ggplot of the survival, hazard, or cumulative-hazard curve, with
 optional KM empirical overlay and population life-table reference. Covers
 the full \verb{tp.hp.dead.*} SAS template family.\tabular{ll}{
    SAS template \tab R usage \cr

--- a/man/hv_followup.Rd
+++ b/man/hv_followup.Rd
@@ -57,7 +57,7 @@ Default \code{1990}.}
 \item{close_date}{Data close date.  Must be \eqn{\geq}
 \code{study_end}.  Default \code{as.Date("2021-08-06")}.}
 
-\item{tolower_names}{Logical; whether to lower-case column names when
+\item{tolower_names}{Logical; if TRUE, column names are lower-cased when
 materialising the data.  Default \code{TRUE}.}
 
 \item{death_levels}{Length-2 character vector labelling the two death

--- a/man/hvtiPlotR-package.Rd
+++ b/man/hvtiPlotR-package.Rd
@@ -8,9 +8,9 @@
 \code{hvtiPlotR} is an R port of the \code{plot.sas} macro suite used by the
 Cardiovascular Outcomes, Registries and Research (CORR) statistics
 group within the Heart, Vascular and Thoracic Institute at the
-Cleveland Clinic. It produces publication-quality graphics that
-conform to HVTI manuscript, poster, and presentation standards using
-\code{ggplot2} and the \code{officer} package.
+Cleveland Clinic. We use it to produce graphics that meet HVTI
+manuscript, poster, and presentation standards, built on \code{ggplot2}
+and the \code{officer} package.
 }
 \details{
 \subsection{Two-step workflow}{
@@ -23,8 +23,9 @@ under \verb{$tables}.
 \item Call \code{plot()} on the object to obtain a bare \code{ggplot2::ggplot}
 you can decorate with scales, labels, annotations, and themes
 without restriction.
-\item Call \code{print()} on the object for a concise console summary.
 }
+
+Calling \code{print()} on the object gives a concise console summary.
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{library(ggplot2)
 library(hvtiPlotR)
@@ -233,9 +234,6 @@ risk tables, group counts, etc.).
 }
 
 \subsection{Sample-data generators}{
-
-Each generator produces realistic synthetic data sized and structured
-to match the corresponding SAS dataset exports.
 \itemize{
 \item \code{\link[=sample_mirror_histogram_data]{sample_mirror_histogram_data()}}: Propensity scores via a logistic
 model with greedy 1:1 caliper matching and optional IPTW weights.
@@ -285,8 +283,8 @@ intersection analysis.
 \subsection{Scope and versioning}{
 
 \code{hvtiPlotR} targets \strong{internal HVTI / CORR use only} — it will not
-be submitted to CRAN. GitHub-only dependencies are first-class
-(\verb{Remotes:} in DESCRIPTION). Install via:
+be submitted to CRAN. GitHub-only dependencies are declared in
+\verb{Remotes:} in DESCRIPTION and install cleanly. Install via:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{remotes::install_github("ehrlinger/hvtiPlotR")
 }\if{html}{\out{</div>}}

--- a/man/hvtiPlotR-themes.Rd
+++ b/man/hvtiPlotR-themes.Rd
@@ -131,22 +131,23 @@ four publication contexts:
 
 Each theme follows the \code{theme_bw()} contract: pass \code{base_size} /
 \code{base_family} to control global typography, then chain a \code{+ theme(...)}
-call to override anything else. Additionally, any extra named argument is
-forwarded straight into a final \code{\link[ggplot2:theme]{ggplot2::theme()}} call so callers can
-tweak elements inline:
+call to override anything else. Any extra named argument goes straight
+into a final \code{\link[ggplot2:theme]{ggplot2::theme()}} call; tweak elements at the call site
+without a separate \code{+} chain:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{theme_hv_manuscript(legend.position = "right")
 theme_hv_ppt_dark(axis.text.y = element_text(family = "mono"))
 }\if{html}{\out{</div>}}
 
-Caller-supplied elements override the hvtiPlotR defaults.
+Your elements override the hvtiPlotR defaults.
 
 \code{theme_hv_ppt_dark()} is the default PPT theme: a black panel with white
 text suited to dark slide backgrounds. Use \code{\link[=theme_hv_ppt_light]{theme_hv_ppt_light()}} when the
-slide template is light. Both PPT themes hide the legend by default --
+slide template is light. Both PPT themes hide the legend by default;
 override with \code{legend.position = "right"} (or chain \code{+ theme(...)}).
 
 Margins on axis text/title are scaled from \code{base_size} via the standard
-\code{half_line = base_size / 2} convention, so spacing stays proportional when
-\code{base_size} changes.
+\code{half_line = base_size / 2} convention; a deck at \code{base_size = 28} and
+one at \code{base_size = 36} both feel proportionate without you touching
+the margins.
 }

--- a/man/make_footnote.Rd
+++ b/man/make_footnote.Rd
@@ -26,13 +26,11 @@ makeFootnote(
 )
 }
 \arguments{
-\item{text}{Text to display. Defaults to the current working directory,
-which conveniently identifies the project. For the typical use case pass
-the script filename: \code{make_footnote("R/analysis.R")}.}
+\item{text}{Text to display. Defaults to the current working directory;
+for most uses pass the script filename instead: \code{make_footnote("R/analysis.R")}.}
 
-\item{timestamp}{Logical; append \code{Sys.time()} to \code{text}? Default \code{TRUE}.
-Set to \code{FALSE} for reproducible screenshots or when the file path already
-contains enough context.}
+\item{timestamp}{Logical; if TRUE, \code{Sys.time()} is appended to \code{text}. Default \code{TRUE}.
+Set to \code{FALSE} for reproducible output.}
 
 \item{prefix}{String prepended to \code{text} before the timestamp. Default
 \code{"DRAFT \\u2014 "}. Set to \code{""} to suppress the prefix.}

--- a/man/nnt_plot.Rd
+++ b/man/nnt_plot.Rd
@@ -43,9 +43,9 @@ A \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 \code{nnt_plot()} has been superseded by the S3 constructor \code{\link[=hv_nnt]{hv_nnt()}} plus
 \code{\link[=plot.hv_nnt]{plot.hv_nnt()}}.
 
-Plots the number needed to treat (NNT) and/or absolute risk reduction (ARR)
-over time, with optional confidence bands. Covers the NNT component of
-\code{tp.hp.numtreat.survdiff.matched.sas}.
+Pass the \code{nntout} dataset and plot NNT (or ARR) over time. Add
+\code{lower_col}/\code{upper_col} for a confidence band. Covers the NNT component
+of \code{tp.hp.numtreat.survdiff.matched.sas}.
 
 \strong{SAS context:} The SAS template computes NNT at discrete time points
 (1, 5, 10, 15, 20 years) from the HAZDIFL macro output, then connects them

--- a/man/plot.hv_alluvial.Rd
+++ b/man/plot.hv_alluvial.Rd
@@ -29,7 +29,7 @@ spacing. Default \code{1/4}.}
 
 \item{knot_pos}{Curvature of the flow ribbons, \eqn{[0,1]}. Default \code{0.4}.}
 
-\item{show_labels}{Logical; whether to label each stratum. Default \code{TRUE}.}
+\item{show_labels}{Logical; if TRUE, each stratum is labelled. Default \code{TRUE}.}
 
 \item{...}{Ignored; present for S3 consistency.}
 }

--- a/man/plot.hv_upset.Rd
+++ b/man/plot.hv_upset.Rd
@@ -49,7 +49,7 @@ intersection-bar ggplot.}
 \item{width_ratio}{Fraction of horizontal space given to the
 set-size sidebar (only used when \code{set_size = TRUE}). Default \code{0.3}.}
 
-\item{...}{Currently unused; reserved for future args.}
+\item{...}{Ignored; present for S3 consistency.}
 }
 \value{
 A \code{ggplot} when \code{set_size = FALSE} (themes apply with \code{+}); a

--- a/man/sample_covariate_balance_data.Rd
+++ b/man/sample_covariate_balance_data.Rd
@@ -14,12 +14,12 @@ sample_covariate_balance_data(
 )
 }
 \arguments{
-\item{n_vars}{Integer. Number of covariates to generate. Default \code{12}.}
+\item{n_vars}{Integer; number of covariates to generate. Default \code{12}.}
 
-\item{n}{Integer. Total number of simulated patients before matching.
+\item{n}{Integer; total number of simulated patients before matching.
 Default \code{600} (roughly 300 per group at \code{separation = 1.5}).}
 
-\item{separation}{Numeric. Distance between the two group means on the
+\item{separation}{Numeric; distance between the two group means on the
 log-odds scale.  Larger values push propensity score distributions
 further apart, increasing the proportion of unmatched extreme-score
 patients and residual imbalance after matching.  Default \code{1.5}.}

--- a/man/sample_mirror_histogram_data.Rd
+++ b/man/sample_mirror_histogram_data.Rd
@@ -15,7 +15,7 @@ sample_mirror_histogram_data(
 \arguments{
 \item{n}{Number of observations \strong{per group} (default 500).}
 
-\item{separation}{Numeric. Distance between the two group means on the
+\item{separation}{Numeric; distance between the two group means on the
 log-odds scale.  Larger values push the score distributions further apart
 and increase the proportion of unmatched patients at the extremes
 (default 1.5).}

--- a/man/sample_stacked_histogram_data.Rd
+++ b/man/sample_stacked_histogram_data.Rd
@@ -12,13 +12,13 @@ sample_stacked_histogram_data(
 )
 }
 \arguments{
-\item{n_years}{Integer. Number of consecutive years to simulate starting
+\item{n_years}{Integer; number of consecutive years to simulate starting
 from \code{start_year}. Defaults to \code{20}.}
 
-\item{start_year}{Integer. First calendar year in the sequence. Defaults to
+\item{start_year}{Integer; first calendar year in the sequence. Defaults to
 \code{2000}.}
 
-\item{n_categories}{Integer. Number of distinct groups. Defaults to \code{3}.}
+\item{n_categories}{Integer; number of distinct groups. Defaults to \code{3}.}
 
 \item{seed}{Integer passed to \code{\link[base]{set.seed}} for
 reproducibility. Defaults to \code{42}.}

--- a/man/survival_difference_plot.Rd
+++ b/man/survival_difference_plot.Rd
@@ -43,7 +43,7 @@ A \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object.
 \code{survival_difference_plot()} has been superseded by the S3 constructor
 \code{\link[=hv_survival_difference]{hv_survival_difference()}} plus \code{\link[=plot.hv_survival_difference]{plot.hv_survival_difference()}}.
 
-Plots the difference in survival between two groups over time, with an
+Pass a \code{diffout} dataset and you get the S_2(t) - S_1(t) curve with an
 optional confidence band. Covers \code{tp.hp.dead.life-gained.sas} and the
 survival-difference component of \code{tp.hp.numtreat.survdiff.matched.sas}.
 

--- a/vignettes/contributing.qmd
+++ b/vignettes/contributing.qmd
@@ -21,12 +21,9 @@ knitr::opts_chunk$set(echo = TRUE, eval = FALSE, message = FALSE,
                       warning = FALSE)
 ```
 
-This guide is for two audiences:
-
-- **Biostatisticians and analysts** who want to port a SAS template to R
-  and add it to this package. Start at [Track A](#track-a).
-- **R package developers** who want to work on testing, CI, or package
-  infrastructure. Start at [Track B](#track-b).
+If you are a biostatistician porting a SAS template to R, start at
+[Track A](#track-a). If you are here for testing, CI, or package
+infrastructure, start at [Track B](#track-b).
 
 ---
 
@@ -40,7 +37,7 @@ This guide is for two audiences:
 
 ## Installing development dependencies
 
-Clone the repository and install all dependencies declared in `DESCRIPTION`:
+Clone the repository and install your development dependencies:
 
 ```r
 # Clone (first time only)
@@ -213,7 +210,7 @@ bmi_curve_plot <- function(curve_data,
 }
 ```
 
-Key rules enforced here:
+A few conventions the function above follows:
 
 - **Column names are strings**, passed via `x_col =`, `estimate_col =`, etc.
   Never use `enquo()` or `{{ }}` — it makes column names opaque to the
@@ -282,7 +279,7 @@ sample_bmi_curve_data <- function(n       = 500,
 
 ## Step 4: Write roxygen documentation
 
-The documentation block must include all of the following:
+Your documentation block needs all of the following:
 
 | Tag | Required | Notes |
 |---|---|---|
@@ -455,7 +452,7 @@ files.
 
 ### The bare-ggplot pattern
 
-Every plot function must:
+Every plot function in hvtiPlotR follows five rules:
 
 1. Accept model-output data frames (not raw patient data).
 2. Map all column references through string arguments (`x_col =`, etc.).
@@ -463,8 +460,9 @@ Every plot function must:
 4. Return an unstyled ggplot — no `scale_*()`, no `labs()`, no theme.
 5. Not call `print()` or `invisible()`.
 
-This pattern lets callers layer on their own choices and enables the
-`+` composition grammar documented in `vignettes/plot-decorators.qmd`.
+Return the bare ggplot and callers can layer scales, labels, and a theme on
+top — that's the `+` composition grammar covered in
+`vignettes/plot-decorators.qmd`.
 
 ### Tidy evaluation
 
@@ -489,8 +487,7 @@ Always declare `.data` in the roxygen block:
 ### Test file layout
 
 Each source file `R/my-plot.R` should have a corresponding
-`tests/testthat/test_my_plot.R`. The minimum set of tests for a new plot
-function:
+`tests/testthat/test_my_plot.R`. At minimum, a new plot function needs five tests:
 
 | Test | What to check |
 |---|---|
@@ -532,8 +529,8 @@ rcmdcheck::rcmdcheck(          # more detailed output
 
 ## Vignette conventions {#vignette-conventions}
 
-Vignettes live in `vignettes/` as `.qmd` files and are built with Quarto
-(`VignetteBuilder: quarto`). Rules:
+Vignettes live in `vignettes/` as `.qmd` files; Quarto builds them
+(`VignetteBuilder: quarto`). A few things to keep in mind:
 
 - All code chunks that read files, write files, or access a network must
   have `#| eval: false`.
@@ -549,10 +546,12 @@ Vignettes live in `vignettes/` as `.qmd` files and are built with Quarto
 1. Update the version in `DESCRIPTION` (follow
    [semantic versioning](https://semver.org/): `MAJOR.MINOR.PATCH`).
 2. Move the dev entries in `NEWS.md` to a new `# hvtiPlotR X.Y.Z` heading.
-3. Run `devtools::check()` — zero errors and zero warnings required.
+3. Run `devtools::check()` — you need zero errors and zero warnings before
+   tagging.
 4. Tag the release commit: `git tag -a vX.Y.Z -m "Release X.Y.Z"`.
 5. Push the tag: `git push origin vX.Y.Z`.
-6. The pkgdown GitHub Action rebuilds the documentation site automatically.
+6. The pkgdown GitHub Action picks up the tag and rebuilds the documentation
+   site — nothing else to do.
 
 ---
 

--- a/vignettes/hvtiPlotR.html
+++ b/vignettes/hvtiPlotR.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="John Ehrlinger ehrlinj@ccf.org">
-<meta name="dcterms.date" content="2026-04-20">
+<meta name="dcterms.date" content="2026-05-22">
 
 <title>The hvtiPlotR package: Generating plot.sas style in R</title>
 <style>
@@ -159,7 +159,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">April 20, 2026</p>
+      <p class="date">May 22, 2026</p>
     </div>
   </div>
   
@@ -173,10 +173,10 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 
 <section id="abstract" class="level1">
 <h1>Abstract</h1>
-<p>We introduce the R package <strong>hvtiPlotR</strong>, tools for creating publication quality graphics in R for the Heart &amp; Vascular Institute Cardiovascular Outcomes Registries and Research (CORR) statistics group at the Cleveland Clinic. The <strong>hvtiPlotR</strong> package contains a tutorial for generating figures (this vignette) and small set of functions for formatting and saving those figures. These tools describe how to generate figures in R to replace the <code>plot.sas</code> macro we currently use in SAS.</p>
+<p>We introduce the R package <strong>hvtiPlotR</strong>, tools for creating publication quality graphics in R for the Heart &amp; Vascular Institute Cardiovascular Outcomes Registries and Research (CORR) statistics group at the Cleveland Clinic. The <strong>hvtiPlotR</strong> package contains a tutorial for generating figures (this vignette) and small set of functions for formatting and saving those figures. We use these tools to generate figures in R as a replacement for the <code>plot.sas</code> macro.</p>
 <p>This package vignette is a tutorial for generating our standard figures using the <code>ggplot2</code> package commands in R. The tutorial presents a series of R recipes for generating figures. The <strong>hvtiPlotR</strong> package includes a set of themes designed to format those figures for inclusion in manuscript and PowerPoint targets.</p>
 <p>This document is included with the <strong>hvtiPlotR</strong> package as a package vignette. The vignette is installed into R when the <strong>hvtiPlotR</strong> package is installed, and viewable using the command: <code>vignette("hvtiPlotR", package="hvtiPlotR")</code>.</p>
-<p>The goal of the vignette is as a tutorial to document the best practices of creating our publication quality graphics for both manuscripts and power point presentations. It is our intent to update this vignette as our standards and the <strong>hvtiPlotR</strong> package are modified.</p>
+<p>This vignette documents our best practices for publication graphics — manuscripts and PowerPoint slides both. We will update it as our standards and the <strong>hvtiPlotR</strong> package evolve.</p>
 <p>Keywords: <em>publication graphics, powerpoint, ggplot2, plot.sas</em>.</p>
 <p>Companion vignettes cover individual plot functions (<a href="plot-functions.html">hvtiPlotR Plot Functions</a>) and plot decoration and saving (<a href="plot-decorators.html">Decorating and Saving hvtiPlotR Plots</a>).</p>
 </section>
@@ -193,8 +193,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="introduction" class="level1">
 <h1>Introduction</h1>
 <p>For many years, the mainstay for generating graphics for manuscripts and presentations in the statistics group in The Heart &amp; Vascular Institute has been the <code>plot.sas</code> macro using SAS. However, we have had issues migrating this macro to newer versions of SAS (&gt; 8.0) and Microsoft Oﬃce products (&gt; 2003).</p>
-<p>In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the <strong>hvtiPlotR</strong> R package. The goal of the package, and this vignette, is simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians will be able to create graphics for publications and presentations with a minimal amount of eﬀort.</p>
-<p>The <strong>hvtiPlotR</strong> package implements best practices for R graphics by leveraging the <code>ggplot2</code> package (Wickham 2009). The <code>ggplot2</code> package is an implementation of the Grammar of Graphics (Wilkinson 2005), which is a formalization of graphical concepts, and the building of graphical objects from a sequence of independent components. These components can be combined in many diﬀerent ways.</p>
+<p>In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the <strong>hvtiPlotR</strong> R package. The goal of the package, and this vignette, is simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians can generate publication-ready graphics without fighting the tooling.</p>
+<p>The <strong>hvtiPlotR</strong> package builds on <code>ggplot2</code> (Wickham 2009) to implement best practices for R graphics. The <code>ggplot2</code> package is an implementation of the Grammar of Graphics (Wilkinson 2005), which is a formalization of graphical concepts, and the building of graphical objects from a sequence of independent components. These components can be combined in many diﬀerent ways.</p>
 <p>The <code>plot.sas</code> macro is also an implementation of a graphics grammar. The grammar <code>plot.sas</code> is derived from the ZETA pen plotters, which used GML (Graphics Machine Language) to control between 4 and and 8 colored pens for generating color line and point figures.</p>
 <pre class="sas"><code>%let STUDY=/studies/cardiac/valves/aortic/replacement/partner_publication_office/partner1b/mortality_5y
 *****************************************************************************;
@@ -514,22 +514,22 @@ tuple set=all , x=years , y=noinit , cll=clinit , clu=cuinit , width =0.5 ,
 <tbody>
 <tr class="odd">
 <td><code>device=pscolor</code></td>
-<td><code>hv_theme("manuscript")</code></td>
+<td><code>theme_hv_manuscript()</code></td>
 <td>Journal PDF, black on white</td>
 </tr>
 <tr class="even">
 <td><code>device=cgmmppa</code> + dark slide</td>
-<td><code>hv_theme("dark_ppt")</code></td>
+<td><code>theme_hv_ppt_dark()</code></td>
 <td>Dark-background PowerPoint</td>
 </tr>
 <tr class="odd">
 <td><code>device=cgmmppa</code> + white slide</td>
-<td><code>hv_theme("light_ppt")</code></td>
+<td><code>theme_hv_ppt_light()</code></td>
 <td>Light/transparent PowerPoint</td>
 </tr>
 <tr class="even">
 <td>—</td>
-<td><code>hv_theme("poster")</code></td>
+<td><code>theme_hv_poster()</code></td>
 <td>Conference poster (larger text)</td>
 </tr>
 </tbody>
@@ -538,7 +538,7 @@ tuple set=all , x=years , y=noinit , cll=clinit , clu=cuinit , width =0.5 ,
 </section>
 <section id="generating-ggplot2-graphics" class="level1">
 <h1>Generating ggplot2 graphics</h1>
-<p>In order to create figures similar to using <code>plot.sas</code> macro, using R, we will make extensive use of the ggplot2 package. This will require translating from the graphics language of plot.sas to the graphics language of ggplot2.</p>
+<p>To create figures comparable to <code>plot.sas</code> output, we rely heavily on <code>ggplot2</code>. This requires translating from the graphics language of <code>plot.sas</code> to the graphics language of <code>ggplot2</code>.</p>
 <p>For the remainder of this document, R code will be highlighted in grey boxes, as shown below. We will refer to these blocks as code chunks. You can run each code chunk individually, using copy/paste into an interactive R session, or within a stand alone R script. This tutorial requires the <strong>hvtiPlotR</strong> package to load the data and themes we will be discussing.</p>
 <pre class="sas"><code>*_____________________________________________________________________;
 * C G M F I L E S F O R P O W E R P O I N T S L I D E S *_____________________________________________________________________ 
@@ -618,7 +618,7 @@ run;</code></pre>
 <span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a><span class="fu">data</span>(nonparametric, <span class="at">package =</span> <span class="st">"hvtiPlotR"</span>)</span>
 <span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a><span class="co"># Set a default hvtiPlotR plotting theme</span></span>
-<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a><span class="fu">theme_set</span>(hvtiPlotR<span class="sc">::</span><span class="fu">hv_theme</span>(<span class="st">"poster"</span>)) </span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a><span class="fu">theme_set</span>(hvtiPlotR<span class="sc">::</span><span class="fu">theme_hv_poster</span>()) </span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 <p>One advantage of ggplot2 is that figures can be built up in successive statements. This tutorial will make extensive use of this to demonstrate the process. Starting in this code chunk, we will save the intermediate objects in the ccf_plot variable. Here we simply create an empty ggplot2 figure that we will be adding to as we work through the commands in the <code>plot.sas</code> macro. Note that we include the %plot() commands in the comments above the equivalent ggplot2 command for comparison.</p>
 <div class="cell">
@@ -686,7 +686,7 @@ run;</code></pre>
 </div>
 </div>
 </div>
-<p>The <code>aes()</code> mechanism is a powerful way to communicate data level assignment to <code>geom_</code> functions. If you want to stratify a dataset by a variable, you can specify that within the <code>aes()</code> function call using the <code>by=</code> argument. For points, we often want the stratifying to be either a diﬀerent <code>color=</code> or <code>shape=</code> for stratified data. We can then use the <code>scale_color_</code> functions (See Section 3.10) or the <code>scale_shape_</code> functions (See Section 3.9) to control how these are assigned to the stratifying variable.</p>
+<p>The <code>aes()</code> mechanism is how you communicate data-level assignment to <code>geom_</code> functions. If you want to stratify a dataset by a variable, you can specify that within the <code>aes()</code> function call using the <code>by=</code> argument. For points, we often want the stratifying to be either a diﬀerent <code>color=</code> or <code>shape=</code> for stratified data. We can then use the <code>scale_color_</code> functions (See Section 3.10) or the <code>scale_shape_</code> functions (See Section 3.9) to control how these are assigned to the stratifying variable.</p>
 <p>Once we have added data to the <code>ggplot</code> object, we can display the figure as shown in Figure 4. Until now the figure has been manipulated by sequentially adding function calls to the <code>ccf_plot object</code>. To display the figure you can either use the <code>show()</code> function, or simply call the object name at the command line.</p>
 <p>Note that we have used the default shape, size and color for this figure. These can be manipulated by adding arguments to the <code>geom_</code> functions, outside of the <code>aes()</code> function, as we will demonstrate in the following sections.</p>
 </section>
@@ -825,10 +825,10 @@ run;</code></pre>
 <section id="colors" class="level2">
 <h2 class="anchored" data-anchor-id="colors">Colors</h2>
 <p>You can specify colors in R by numeric index, name (as we have done), hexadecimal, or RGB specification. For example <code>col=1</code> and <code>col="white"</code> are equivalent. The chart in Figure 9 was produced with code developed by Glynn (2005). See his R Color Chart website for all the details you would ever need about using colors in R.</p>
-<p>Color theory encompasses a multitude of definitions, concepts and design applications - enough to fill several encyclopedias. However, there are three basic categories of color theory that are logical and useful : The color wheel, color harmony, and the context of how colors are used. ColorBrewer (Harrower and Brewer 2003) is an online tool (http://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We encourage the use of ColorBrewer as a good, safe introduction to selecting colors based on theoretically good practices.</p>
+<p>ColorBrewer (Harrower and Brewer 2003) is an online tool (http://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We recommend it as a practical starting point for choosing colors grounded in sound design principles.</p>
 <p>Figure 8: ggplot2 shape table</p>
 <p>Figure 9: R colors</p>
-<p>The RColorBrewer package (Neuwirth 2011) simplifies the selection of ColorBrewer colors into R. We have used RColorBrewer to get a list of colors, and assign colors manually to specific variable values using the <code>ggplot</code> <code>aes()</code> mechanism. The ColorBrewer palettes have also been built into the <code>ggplot</code> <code>scale_</code> functions in the <code>scale_color_brewer</code> function. We have made extensive use of the <code>palette="Set1"</code> color palette in figures we have generated. There are also a series of other <code>scale_color_</code> functions in ggplot2 to aid the user in selecting good color schemes for many diﬀerent settings.</p>
+<p>The ColorBrewer palette catalogue (Harrower and Brewer 2003) is built into <code>ggplot2</code> via <code>scale_colour_brewer()</code> / <code>scale_fill_brewer()</code>; hvtiPlotR does not import the optional <code>RColorBrewer</code> package. We have made extensive use of the <code>palette = "Set1"</code> colour palette in the figures we have generated. There are also a series of other <code>scale_colour_*</code> functions in ggplot2 to aid the user in selecting good colour schemes for many diﬀerent settings — consult <a href="https://colorbrewer2.org/" class="uri">https://colorbrewer2.org/</a> for an interactive palette browser.</p>
 </section>
 <section id="global-figure-commands" class="level2">
 <h2 class="anchored" data-anchor-id="global-figure-commands">Global Figure Commands</h2>
@@ -902,9 +902,9 @@ run;</code></pre>
 </section>
 <section id="themes-and-decoration" class="level1">
 <h1>Themes and Decoration</h1>
-<p>The <strong>hvtiPlotR</strong> package provides four themes via <code>hv_theme(style)</code>: <code>"manuscript"</code>, <code>"poster"</code>, <code>"light_ppt"</code>, and <code>"dark_ppt"</code>. Apply the theme as the last <code>+</code> layer on any composed ggplot object.</p>
+<p>The <strong>hvtiPlotR</strong> package provides four themes via <code>theme_hv_*()</code>: <code>"manuscript"</code>, <code>"poster"</code>, <code>"light_ppt"</code>, and <code>"dark_ppt"</code>. Apply the theme as the last <code>+</code> layer on any composed ggplot object.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb26"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>p_final <span class="ot">&lt;-</span> ccf_plot <span class="sc">+</span> <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb26"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>p_final <span class="ot">&lt;-</span> ccf_plot <span class="sc">+</span> <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>p_final</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output cell-output-stderr">
 <pre><code>Warning: Removed 7 rows containing missing values or values outside the scale range
@@ -943,9 +943,9 @@ run;</code></pre>
 </section>
 <section id="powerpoint-graphics" class="level2">
 <h2 class="anchored" data-anchor-id="powerpoint-graphics">PowerPoint graphics</h2>
-<p>Use <code>save_ppt()</code> to insert a ggplot as an editable vector graphic into a PowerPoint file. Apply <code>hv_theme("dark_ppt")</code> or <code>hv_theme("light_ppt")</code> before saving.</p>
+<p>Use <code>save_ppt()</code> to insert a ggplot as an editable vector graphic into a PowerPoint file. Apply <code>theme_hv_ppt_dark()</code> or <code>theme_hv_ppt_light()</code> before saving.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb30"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>p_ppt <span class="ot">&lt;-</span> ccf_pptPlot <span class="sc">+</span> <span class="fu">hv_theme</span>(<span class="st">"dark_ppt"</span>)</span>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb30"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>p_ppt <span class="ot">&lt;-</span> ccf_pptPlot <span class="sc">+</span> <span class="fu">theme_hv_ppt_dark</span>()</span>
 <span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a><span class="fu">save_ppt</span>(</span>
 <span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">object       =</span> p_ppt,</span>
@@ -962,7 +962,7 @@ run;</code></pre>
 <section id="manuscript-figures" class="level2">
 <h2 class="anchored" data-anchor-id="manuscript-figures">Manuscript figures</h2>
 <ul>
-<li><strong>Use <code>hv_theme("manuscript")</code></strong> — black text, white background, no decorative fill. Never use coloured backgrounds in figures destined for journals.</li>
+<li><strong>Use <code>theme_hv_manuscript()</code></strong> — black text, white background, no decorative fill. Never use coloured backgrounds in figures destined for journals.</li>
 <li><strong>No chart titles</strong> — the figure caption in the manuscript text carries the title. Do not add a <code>labs(title = ...)</code> layer.</li>
 <li><strong>Axis labels are mandatory</strong> — always supply <code>labs(x = ..., y = ...)</code>. Units belong in the axis label, not in the tick labels (e.g.&nbsp;<code>"Years after operation"</code>, not <code>"0 yr, 5 yr, 10 yr"</code>).</li>
 <li><strong>Percent axes</strong> — format y-axis tick labels as <code>"0%"</code>, <code>"20%"</code>, …, <code>"100%"</code> using <code>scale_y_continuous(labels = function(x) paste0(x, "%"))</code>. Do not write the <code>%</code> symbol inside the axis title.</li>
@@ -975,7 +975,7 @@ run;</code></pre>
 <section id="powerpoint-figures-1" class="level2">
 <h2 class="anchored" data-anchor-id="powerpoint-figures-1">PowerPoint figures</h2>
 <ul>
-<li><strong>Use <code>hv_theme("dark_ppt")</code> or <code>hv_theme("light_ppt")</code></strong> — the dark theme is the default for Cleveland Clinic presentation templates. Match the theme to the slide background colour.</li>
+<li><strong>Use <code>theme_hv_ppt_dark()</code> or <code>theme_hv_ppt_light()</code></strong> — the dark theme is the default for Cleveland Clinic presentation templates. Match the theme to the slide background colour.</li>
 <li><strong>No points on parametric curves</strong> — presentation figures show lines only. Points are reserved for nonparametric data summaries.</li>
 <li><strong>Larger line widths</strong> — use <code>linewidth = 1.5</code> or higher so lines are clearly visible on a projected screen. The SAS equivalent was <code>width=3</code>.</li>
 <li><strong>Fewer axis ticks</strong> — five or six ticks per axis is the maximum for slides. Use <code>scale_x_continuous(breaks = seq(0, 10, 2))</code> to control spacing.</li>
@@ -986,7 +986,7 @@ run;</code></pre>
 <section id="colour" class="level2">
 <h2 class="anchored" data-anchor-id="colour">Colour</h2>
 <ul>
-<li><strong>Multi-group figures</strong> — use <code>scale_colour_brewer(palette = "Set1")</code> for up to five groups. For more groups, select a palette manually or use <code>RColorBrewer::brewer.pal()</code> to inspect options.</li>
+<li><strong>Multi-group figures</strong> — use <code>scale_colour_brewer(palette = "Set1")</code> for up to five groups. For more groups, either pass an explicit vector of hex codes via <code>scale_colour_manual()</code> or browse the ColorBrewer palette catalogue at <a href="https://colorbrewer2.org/" class="uri">https://colorbrewer2.org/</a>. (ggplot2 ships the Brewer palette table internally; hvtiPlotR does not depend on the optional <code>RColorBrewer</code> package.)</li>
 <li><strong>Single-group survival/hazard figures</strong> — <code>"steelblue"</code> for manuscript, <code>"white"</code> for dark PPT.</li>
 <li><strong>Avoid red/green combinations</strong> — approximately 8% of men have red–green colour blindness. Use shape (<code>scale_shape_manual()</code>) and linetype (<code>scale_linetype_manual()</code>) in addition to colour so figures remain readable in greyscale print.</li>
 <li><strong>Fills vs colours</strong> — <code>scale_colour_*()</code> controls lines and points; <code>scale_fill_*()</code> controls ribbons and bars. Both must be set consistently when a legend is shown.</li>
@@ -995,11 +995,9 @@ run;</code></pre>
 <section id="what-not-to-include" class="level2">
 <h2 class="anchored" data-anchor-id="what-not-to-include">What not to include</h2>
 <ul>
-<li>No decorative 3-D effects, drop shadows, or gradients.</li>
-<li>No background images or watermarks.</li>
-<li>No more than six groups per panel — split into separate figures if needed.</li>
-<li>No axis tick marks on the top or right-hand sides.</li>
-<li>No connecting lines between non-adjacent data points unless the relationship is continuous (e.g., a survival curve).</li>
+<li>No decorative 3-D effects, drop shadows, gradients, background images, or watermarks — they distract from the data.</li>
+<li>No axis tick marks on the top or right sides. No more than six groups per panel; split into separate figures if you need more.</li>
+<li>No connecting lines between non-adjacent data points unless the relationship is genuinely continuous (e.g., a survival curve).</li>
 </ul>
 </section>
 </section>

--- a/vignettes/hvtiPlotR.html
+++ b/vignettes/hvtiPlotR.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="John Ehrlinger ehrlinj@ccf.org">
-<meta name="dcterms.date" content="2026-05-22">
+<meta name="dcterms.date" content="2026-05-26">
 
 <title>The hvtiPlotR package: Generating plot.sas style in R</title>
 <style>
@@ -159,7 +159,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 22, 2026</p>
+      <p class="date">May 26, 2026</p>
     </div>
   </div>
   
@@ -193,7 +193,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="introduction" class="level1">
 <h1>Introduction</h1>
 <p>For many years, the mainstay for generating graphics for manuscripts and presentations in the statistics group in The Heart &amp; Vascular Institute has been the <code>plot.sas</code> macro using SAS. However, we have had issues migrating this macro to newer versions of SAS (&gt; 8.0) and Microsoft Oﬃce products (&gt; 2003).</p>
-<p>In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the <strong>hvtiPlotR</strong> R package. The goal of the package, and this vignette, is simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians can generate publication-ready graphics without fighting the tooling.</p>
+<p>In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the <strong>hvtiPlotR</strong> R package. The goal of the package, and this vignette, is to simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians can generate publication-ready graphics without fighting the tooling.</p>
 <p>The <strong>hvtiPlotR</strong> package builds on <code>ggplot2</code> (Wickham 2009) to implement best practices for R graphics. The <code>ggplot2</code> package is an implementation of the Grammar of Graphics (Wilkinson 2005), which is a formalization of graphical concepts, and the building of graphical objects from a sequence of independent components. These components can be combined in many diﬀerent ways.</p>
 <p>The <code>plot.sas</code> macro is also an implementation of a graphics grammar. The grammar <code>plot.sas</code> is derived from the ZETA pen plotters, which used GML (Graphics Machine Language) to control between 4 and and 8 colored pens for generating color line and point figures.</p>
 <pre class="sas"><code>%let STUDY=/studies/cardiac/valves/aortic/replacement/partner_publication_office/partner1b/mortality_5y
@@ -902,7 +902,7 @@ run;</code></pre>
 </section>
 <section id="themes-and-decoration" class="level1">
 <h1>Themes and Decoration</h1>
-<p>The <strong>hvtiPlotR</strong> package provides four themes via <code>theme_hv_*()</code>: <code>"manuscript"</code>, <code>"poster"</code>, <code>"light_ppt"</code>, and <code>"dark_ppt"</code>. Apply the theme as the last <code>+</code> layer on any composed ggplot object.</p>
+<p>The <strong>hvtiPlotR</strong> package provides four <code>theme_hv_*()</code> functions — <code>theme_hv_manuscript()</code>, <code>theme_hv_poster()</code>, <code>theme_hv_ppt_light()</code>, and <code>theme_hv_ppt_dark()</code>. Apply one as the last <code>+</code> layer on any composed ggplot object.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb26"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>p_final <span class="ot">&lt;-</span> ccf_plot <span class="sc">+</span> <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>p_final</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>

--- a/vignettes/hvtiPlotR.qmd
+++ b/vignettes/hvtiPlotR.qmd
@@ -17,13 +17,13 @@ vignette: >
 
 # Abstract
 
-We introduce the R package **hvtiPlotR**, tools for creating publication quality graphics in R for the Heart & Vascular Institute Cardiovascular Outcomes Registries and Research (CORR) statistics group at the Cleveland Clinic. The **hvtiPlotR** package contains a tutorial for generating figures (this vignette) and small set of functions for formatting and saving those figures. These tools describe how to generate figures in R to replace the `plot.sas` macro we currently use in SAS.
+We introduce the R package **hvtiPlotR**, tools for creating publication quality graphics in R for the Heart & Vascular Institute Cardiovascular Outcomes Registries and Research (CORR) statistics group at the Cleveland Clinic. The **hvtiPlotR** package contains a tutorial for generating figures (this vignette) and small set of functions for formatting and saving those figures. We use these tools to generate figures in R as a replacement for the `plot.sas` macro.
 
 This package vignette is a tutorial for generating our standard figures using the `ggplot2` package commands in R. The tutorial presents a series of R recipes for generating figures. The **hvtiPlotR** package includes a set of themes designed to format those figures for inclusion in manuscript and PowerPoint targets.
 
 This document is included with the **hvtiPlotR** package as a package vignette. The vignette is installed into R when the **hvtiPlotR** package is installed, and viewable using the command: `vignette("hvtiPlotR", package="hvtiPlotR")`.
 
-The goal of the vignette is as a tutorial to document the best practices of creating our publication quality graphics for both manuscripts and power point presentations. It is our intent to update this vignette as our standards and the **hvtiPlotR** package are modified.
+This vignette documents our best practices for publication graphics — manuscripts and PowerPoint slides both. We will update it as our standards and the **hvtiPlotR** package evolve.
 
 Keywords: *publication graphics, powerpoint, ggplot2, plot.sas*.
 
@@ -49,9 +49,9 @@ We invite comments, feature requests and bug reports for this package at https:/
 
 For many years, the mainstay for generating graphics for manuscripts and presentations in the statistics group in The Heart & Vascular Institute has been the `plot.sas` macro using SAS. However, we have had issues migrating this macro to newer versions of SAS (\> 8.0) and Microsoft Oﬃce products (\> 2003).
 
-In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the **hvtiPlotR** R package. The goal of the package, and this vignette, is simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians will be able to create graphics for publications and presentations with a minimal amount of eﬀort.
+In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the **hvtiPlotR** R package. The goal of the package, and this vignette, is simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians can generate publication-ready graphics without fighting the tooling.
 
-The **hvtiPlotR** package implements best practices for R graphics by leveraging the `ggplot2` package (Wickham 2009). The `ggplot2` package is an implementation of the Grammar of Graphics (Wilkinson 2005), which is a formalization of graphical concepts, and the building of graphical objects from a sequence of independent components. These components can be combined in many diﬀerent ways.
+The **hvtiPlotR** package builds on `ggplot2` (Wickham 2009) to implement best practices for R graphics. The `ggplot2` package is an implementation of the Grammar of Graphics (Wilkinson 2005), which is a formalization of graphical concepts, and the building of graphical objects from a sequence of independent components. These components can be combined in many diﬀerent ways.
 
 The `plot.sas` macro is also an implementation of a graphics grammar. The grammar `plot.sas` is derived from the ZETA pen plotters, which used GML (Graphics Machine Language) to control between 4 and and 8 colored pens for generating color line and point figures.
 
@@ -213,7 +213,7 @@ shapes to named factor levels rather than setting `shape =` directly.
 
 # Generating ggplot2 graphics
 
-In order to create figures similar to using `plot.sas` macro, using R, we will make extensive use of the ggplot2 package. This will require translating from the graphics language of plot.sas to the graphics language of ggplot2.
+To create figures comparable to `plot.sas` output, we rely heavily on `ggplot2`. This requires translating from the graphics language of `plot.sas` to the graphics language of `ggplot2`.
 
 For the remainder of this document, R code will be highlighted in grey boxes, as shown below. We will refer to these blocks as code chunks. You can run each code chunk individually, using copy/paste into an interactive R session, or within a stand alone R script. This tutorial requires the **hvtiPlotR** package to load the data and themes we will be discussing.
 
@@ -403,7 +403,7 @@ ccf_plot <- ccf_plot +
 show(ccf_plot)
 ```
 
-The `aes()` mechanism is a powerful way to communicate data level assignment to `geom_` functions. If you want to stratify a dataset by a variable, you can specify that within the `aes()` function call using the `by=` argument. For points, we often want the stratifying to be either a diﬀerent `color=` or `shape=` for stratified data. We can then use the `scale_color_` functions (See Section 3.10) or the `scale_shape_` functions (See Section 3.9) to control how these are assigned to the stratifying variable.
+The `aes()` mechanism is how you communicate data-level assignment to `geom_` functions. If you want to stratify a dataset by a variable, you can specify that within the `aes()` function call using the `by=` argument. For points, we often want the stratifying to be either a diﬀerent `color=` or `shape=` for stratified data. We can then use the `scale_color_` functions (See Section 3.10) or the `scale_shape_` functions (See Section 3.9) to control how these are assigned to the stratifying variable.
 
 Once we have added data to the `ggplot` object, we can display the figure as shown in Figure 4. Until now the figure has been manipulated by sequentially adding function calls to the `ccf_plot object`. To display the figure you can either use the `show()` function, or simply call the object name at the command line.
 
@@ -520,7 +520,7 @@ The shape argument takes numeric arguments. Though not user friendly, this metho
 ## Colors 
 You can specify colors in R by numeric index, name (as we have done), hexadecimal, or RGB specification. For example `col=1` and `col="white"` are equivalent. The chart in Figure 9 was produced with code developed by Glynn (2005). See his R Color Chart website for all the details you would ever need about using colors in R.
 
-Color theory encompasses a multitude of definitions, concepts and design applications - enough to fill several encyclopedias. However, there are three basic categories of color theory that are logical and useful : The color wheel, color harmony, and the context of how colors are used. ColorBrewer (Harrower and Brewer 2003) is an online tool (http://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We encourage the use of ColorBrewer as a good, safe introduction to selecting colors based on theoretically good practices.
+ColorBrewer (Harrower and Brewer 2003) is an online tool (http://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We recommend it as a practical starting point for choosing colors grounded in sound design principles.
 
 
 Figure 8: ggplot2 shape table
@@ -708,12 +708,9 @@ them; the rest are conventions to keep in mind when composing figures.
 
 ## What not to include
 
-- No decorative 3-D effects, drop shadows, or gradients.
-- No background images or watermarks.
-- No more than six groups per panel — split into separate figures if needed.
-- No axis tick marks on the top or right-hand sides.
-- No connecting lines between non-adjacent data points unless the relationship
-  is continuous (e.g., a survival curve).
+- No decorative 3-D effects, drop shadows, gradients, background images, or watermarks — they distract from the data.
+- No axis tick marks on the top or right sides. No more than six groups per panel; split into separate figures if you need more.
+- No connecting lines between non-adjacent data points unless the relationship is genuinely continuous (e.g., a survival curve).
 
 
 # Conclusions 

--- a/vignettes/hvtiPlotR.qmd
+++ b/vignettes/hvtiPlotR.qmd
@@ -49,7 +49,7 @@ We invite comments, feature requests and bug reports for this package at https:/
 
 For many years, the mainstay for generating graphics for manuscripts and presentations in the statistics group in The Heart & Vascular Institute has been the `plot.sas` macro using SAS. However, we have had issues migrating this macro to newer versions of SAS (\> 8.0) and Microsoft Oﬃce products (\> 2003).
 
-In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the **hvtiPlotR** R package. The goal of the package, and this vignette, is simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians can generate publication-ready graphics without fighting the tooling.
+In an eﬀort to alleviate these version issues, and to standardize the generation of figures within R, we have developed the **hvtiPlotR** R package. The goal of the package, and this vignette, is to simplify the creation of publication quality graphics in R. We are specifically encoding the best practices of the HVTI Clinical Outcomes Research and Registries (CORR) formatting, so that our statisticians can generate publication-ready graphics without fighting the tooling.
 
 The **hvtiPlotR** package builds on `ggplot2` (Wickham 2009) to implement best practices for R graphics. The `ggplot2` package is an implementation of the Grammar of Graphics (Wilkinson 2005), which is a formalization of graphical concepts, and the building of graphical objects from a sequence of independent components. These components can be combined in many diﬀerent ways.
 
@@ -582,9 +582,10 @@ show(ccf_pptPlot)
 
 # Themes and Decoration
 
-The **hvtiPlotR** package provides four themes via `theme_hv_*()`:
-`"manuscript"`, `"poster"`, `"light_ppt"`, and `"dark_ppt"`. Apply the theme
-as the last `+` layer on any composed ggplot object.
+The **hvtiPlotR** package provides four `theme_hv_*()` functions —
+`theme_hv_manuscript()`, `theme_hv_poster()`, `theme_hv_ppt_light()`, and
+`theme_hv_ppt_dark()`. Apply one as the last `+` layer on any composed ggplot
+object.
 
 ```{r man_theme_demo}
 p_final <- ccf_plot + theme_hv_poster()

--- a/vignettes/plot-decorators.html
+++ b/vignettes/plot-decorators.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="John Ehrlinger ehrlinj@ccf.org">
-<meta name="dcterms.date" content="2026-04-20">
+<meta name="dcterms.date" content="2026-05-22">
 
 <title>Decorating and Saving hvtiPlotR Plots</title>
 <style>
@@ -114,6 +114,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
   <ul class="collapse">
   <li><a href="#single-slide" id="toc-single-slide" class="nav-link" data-scroll-target="#single-slide">Single slide</a></li>
   <li><a href="#multiple-slides-from-a-list" id="toc-multiple-slides-from-a-list" class="nav-link" data-scroll-target="#multiple-slides-from-a-list">Multiple slides from a list</a></li>
+  <li><a href="#fixed-panel-placement-across-slides" id="toc-fixed-panel-placement-across-slides" class="nav-link" data-scroll-target="#fixed-panel-placement-across-slides">Fixed panel placement across slides</a></li>
   </ul></li>
   <li><a href="#multi-panel-pdf-eda-batch-output" id="toc-multi-panel-pdf-eda-batch-output" class="nav-link" data-scroll-target="#multi-panel-pdf-eda-batch-output">Multi-panel PDF (EDA batch output)</a></li>
   </ul></li>
@@ -164,7 +165,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">April 20, 2026</p>
+      <p class="date">May 22, 2026</p>
     </div>
   </div>
   
@@ -190,14 +191,14 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </div>
 <section id="the-composition-pattern" class="level1">
 <h1>The Composition Pattern</h1>
-<p>Every hvtiPlotR plot is built in two steps: a constructor (<code>hv_*()</code>) that shapes the data, followed by <code>plot()</code> that renders a bare <code>ggplot</code> object. No colour scales, axis labels, or theme are applied by either step. Decoration is added by chaining layers with <code>+</code>:</p>
+<p>Every hvtiPlotR plot is built in two steps: a constructor (<code>hv_*()</code>) that shapes the data, followed by <code>plot()</code> that renders a bare <code>ggplot</code> object. No colour scales, axis labels, or theme are applied by either step — you add those by chaining layers with <code>+</code>:</p>
 <pre><code>plot(hv_*(...)) +
   scale_colour_*() +   # data colours
   scale_fill_*()   +   # fill colours
   labs()           +   # axis labels, title, caption
   annotate()       +   # text/arrows placed on the panel
   coord_cartesian() +  # viewport cropping
-  hv_theme()         # non-data formatting</code></pre>
+  theme_hv_manuscript()         # non-data formatting</code></pre>
 <p>This vignette demonstrates each decorator in turn, using <code>hv_trends()</code> and <code>hv_survival()</code> as representative base plots.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb3"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Trends data — multi-group continuous outcome over time</span></span>
@@ -211,7 +212,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="themes" class="level1">
 <h1>Themes</h1>
-<p>The <strong>hvtiPlotR</strong> package provides four themes via <code>hv_theme(style)</code>. The <code>style</code> argument selects the output target.</p>
+<p>The <strong>hvtiPlotR</strong> package provides four themes via <code>theme_hv_*()</code>. The <code>style</code> argument selects the output target.</p>
 <table class="caption-top table">
 <thead>
 <tr class="header">
@@ -249,13 +250,13 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
 <span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"manuscript"</span>)</span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_manuscript</span>()</span>
 <span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a>p_ms</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
-<p><img src="plot-decorators_files/figure-html/theme_manuscript-1.png" class="img-fluid figure-img" width="672"></p>
+<p><img src="plot-decorators_files/figure-html/theme_hv_manuscript-1.png" class="img-fluid figure-img" width="672"></p>
 </figure>
 </div>
 </div>
@@ -272,13 +273,13 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
 <span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>p_poster</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
-<p><img src="plot-decorators_files/figure-html/theme_poster-1.png" class="img-fluid figure-img" width="672"></p>
+<p><img src="plot-decorators_files/figure-html/theme_hv_poster-1.png" class="img-fluid figure-img" width="672"></p>
 </figure>
 </div>
 </div>
@@ -295,11 +296,11 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
 <span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"light_ppt"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_ppt_light</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
-<p><img src="plot-decorators_files/figure-html/theme_light_ppt-1.png" class="img-fluid figure-img" width="672"></p>
+<p><img src="plot-decorators_files/figure-html/theme_hv_ppt_light-1.png" class="img-fluid figure-img" width="672"></p>
 </figure>
 </div>
 </div>
@@ -316,12 +317,12 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
 <span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"dark_ppt"</span>) <span class="sc">+</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_ppt_dark</span>() <span class="sc">+</span></span>
 <span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(<span class="at">plot.background =</span> <span class="fu">element_rect</span>(<span class="at">fill =</span> <span class="st">"navy"</span>, <span class="at">colour =</span> <span class="st">"navy"</span>))</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
-<p><img src="plot-decorators_files/figure-html/theme_dark_ppt-1.png" class="img-fluid figure-img" width="672"></p>
+<p><img src="plot-decorators_files/figure-html/theme_hv_ppt_dark-1.png" class="img-fluid figure-img" width="672"></p>
 </figure>
 </div>
 </div>
@@ -330,7 +331,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="colour-scales" class="level1">
 <h1>Colour Scales</h1>
-<p><code>scale_colour_*</code> controls line and point colours; <code>scale_fill_*</code> controls filled areas (ribbons, bars). Both share the same <code>name</code> (legend title) and <code>guide</code> (legend display) arguments.</p>
+<p><code>scale_colour_*</code> controls line and point colours; <code>scale_fill_*</code> controls filled areas (ribbons, bars). Both take the same <code>name</code> (legend title) and <code>guide</code> (legend display) arguments — set them once and both scales update.</p>
 <section id="manual-colours" class="level2">
 <h2 class="anchored" data-anchor-id="manual-colours">Manual colours</h2>
 <p>Use <code>scale_colour_manual()</code> when assigning specific brand or convention colours to known levels.</p>
@@ -343,7 +344,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
 <span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
 <span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Freedom from Death (%)"</span>) <span class="sc">+</span></span>
-<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -355,7 +356,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="colorbrewer-palettes" class="level2">
 <h2 class="anchored" data-anchor-id="colorbrewer-palettes">ColorBrewer palettes</h2>
-<p><code>scale_colour_brewer()</code> applies a ColorBrewer palette — safe, perceptually uniform, and print-friendly. Use <code>palette = "Set1"</code> for categorical data, <code>"RdYlGn"</code> for diverging, <code>"Blues"</code> for sequential.</p>
+<p><code>scale_colour_brewer()</code> applies a ColorBrewer palette — perceptually uniform and print-safe, which matters when figures go to black-and-white PDF. Use <code>palette = "Set1"</code> for categorical data, <code>"RdYlGn"</code> for diverging, <code>"Blues"</code> for sequential.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb9"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
 <span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
@@ -365,7 +366,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
 <span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -377,7 +378,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="suppressing-legends" class="level2">
 <h2 class="anchored" data-anchor-id="suppressing-legends">Suppressing legends</h2>
-<p>Pass <code>guide = "none"</code> to any scale to remove its legend entry. Use this when colour is self-evident from axis labels or annotations.</p>
+<p>Pass <code>guide = "none"</code> to any scale and that aesthetic drops out of the legend. You’d do this when the axis labels or an annotation already name the group — a redundant legend only takes up panel space.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb10"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
 <span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Dark2"</span>, <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
@@ -387,7 +388,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">guide =</span> <span class="st">"none"</span></span>
 <span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -402,7 +403,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h1>Labels and Annotations</h1>
 <section id="labs" class="level2">
 <h2 class="anchored" data-anchor-id="labs">labs()</h2>
-<p><code>labs()</code> sets the axis, legend, title, subtitle, and caption text. Set axis labels here rather than inside the plot function so they can be overridden per project.</p>
+<p><code>labs()</code> sets axis labels, the plot title, legend title, subtitle, and caption text. We set these outside the constructor so you can override them per project without touching the function itself.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb11"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km) <span class="sc">+</span></span>
 <span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
@@ -417,7 +418,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb11-11"><a href="#cb11-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">y       =</span> <span class="st">"Freedom from Death (%)"</span>,</span>
 <span id="cb11-12"><a href="#cb11-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">caption =</span> <span class="st">"Logit CI, \u03b1 = 0.6827 (1 SD)"</span></span>
 <span id="cb11-13"><a href="#cb11-13" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb11-14"><a href="#cb11-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -429,7 +430,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="annotate" class="level2">
 <h2 class="anchored" data-anchor-id="annotate">annotate()</h2>
-<p><code>annotate()</code> places text, segments, or rectangles at fixed data coordinates. Use it for sample size callouts, phase labels, or directional arrows.</p>
+<p><code>annotate()</code> places text, segments, rectangles, or arrows at fixed data coordinates — useful for a sample-size callout in the corner or a label pointing to an event of interest.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb12"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km) <span class="sc">+</span></span>
 <span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
@@ -446,7 +447,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>           <span class="at">arrow =</span> <span class="fu">arrow</span>(<span class="at">length =</span> <span class="fu">unit</span>(<span class="fl">0.2</span>, <span class="st">"cm"</span>)), <span class="at">colour =</span> <span class="st">"grey40"</span>) <span class="sc">+</span></span>
 <span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>,    <span class="at">x =</span> <span class="fl">10.3</span>, <span class="at">y =</span> <span class="dv">40</span>,</span>
 <span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a>           <span class="at">label =</span> <span class="st">"Median survival"</span>, <span class="at">hjust =</span> <span class="dv">0</span>, <span class="at">size =</span> <span class="dv">3</span>, <span class="at">colour =</span> <span class="st">"grey40"</span>) <span class="sc">+</span></span>
-<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -469,7 +470,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
 <span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">1995</span>, <span class="dv">2020</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">20</span>, <span class="dv">70</span>)) <span class="sc">+</span></span>
-<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -496,7 +497,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="poster-pdf" class="level2">
 <h2 class="anchored" data-anchor-id="poster-pdf">Poster PDF</h2>
-<p>Poster figures are typically larger and use <code>hv_theme("poster")</code>. Adjust dimensions to match the poster panel size.</p>
+<p>Poster figures are typically larger and use <code>theme_hv_poster()</code>. Adjust dimensions to match the poster panel size.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb15"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="fu">ggsave</span>(</span>
 <span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">filename =</span> <span class="st">"../graphs/trends_poster.pdf"</span>,</span>
@@ -561,7 +562,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </tr>
 </tbody>
 </table>
-<p>Apply <code>hv_theme("dark_ppt")</code> or <code>hv_theme("light_ppt")</code> before saving to match the slide background.</p>
+<p>Apply <code>theme_hv_ppt_dark()</code> or <code>theme_hv_ppt_light()</code> before saving to match the slide background.</p>
 <section id="single-slide" class="level3">
 <h3 class="anchored" data-anchor-id="single-slide">Single slide</h3>
 <div class="cell">
@@ -575,7 +576,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
 <span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
 <span id="cb16-10"><a href="#cb16-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome (%)"</span>) <span class="sc">+</span></span>
-<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"dark_ppt"</span>)</span>
+<span id="cb16-11"><a href="#cb16-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_ppt_dark</span>()</span>
 <span id="cb16-12"><a href="#cb16-12" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb16-13"><a href="#cb16-13" aria-hidden="true" tabindex="-1"></a><span class="fu">save_ppt</span>(</span>
 <span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>  <span class="at">object       =</span> p_ppt,</span>
@@ -600,7 +601,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb17-9"><a href="#cb17-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
 <span id="cb17-10"><a href="#cb17-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
 <span id="cb17-11"><a href="#cb17-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Freedom from Death (%)"</span>) <span class="sc">+</span></span>
-<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"dark_ppt"</span>)</span>
+<span id="cb17-12"><a href="#cb17-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_ppt_dark</span>()</span>
 <span id="cb17-13"><a href="#cb17-13" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb17-14"><a href="#cb17-14" aria-hidden="true" tabindex="-1"></a><span class="fu">save_ppt</span>(</span>
 <span id="cb17-15"><a href="#cb17-15" aria-hidden="true" tabindex="-1"></a>  <span class="at">object       =</span> <span class="fu">list</span>(<span class="at">trends =</span> p_ppt, <span class="at">survival =</span> p_km_ppt),</span>
@@ -610,60 +611,75 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb17-19"><a href="#cb17-19" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 </section>
+<section id="fixed-panel-placement-across-slides" class="level3">
+<h3 class="anchored" data-anchor-id="fixed-panel-placement-across-slides">Fixed panel placement across slides</h3>
+<p>When plots have different y-axis ranges (“0-1” vs “0-10000”), the axis-label widths differ, which shifts the plot panel inside a fixed <code>ph_location()</code>. On dark PPT themes with a visible panel background (black panel on a blue-gradient slide), that shift is visually jarring — the box appears to move between slides.</p>
+<p>Pass <code>panel_box = list(width, height, left, top)</code> to anchor the <strong>panel content area</strong> at the same slide coordinates on every slide. <code>save_ppt()</code> calls <code>hv_ph_location()</code> for each plot, measures the axis/legend/title chrome around the panel, and adjusts per-slide placement so the panel lands at the target rectangle regardless of label width. Axis labels then extend outside the panel box as needed; device dimensions vary per plot.</p>
+<div class="cell">
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb18"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">save_ppt</span>(</span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">object       =</span> <span class="fu">list</span>(<span class="at">trends =</span> p_ppt, <span class="at">survival =</span> p_km_ppt),</span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">template     =</span> template,</span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">powerpoint   =</span> here<span class="sc">::</span><span class="fu">here</span>(<span class="st">"graphs"</span>, <span class="st">"multi_slide_deck_aligned.pptx"</span>),</span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">slide_titles =</span> <span class="fu">c</span>(<span class="st">"Temporal Trends by Group"</span>, <span class="st">"Overall Survival"</span>),</span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">panel_box    =</span> <span class="fu">list</span>(<span class="at">width =</span> <span class="dv">10</span>, <span class="at">height =</span> <span class="dv">5</span>, <span class="at">left =</span> <span class="fl">1.5</span>, <span class="at">top =</span> <span class="fl">1.5</span>)</span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+</div>
+<p>Make <code>panel_left</code> / <code>panel_top</code> large enough to leave room for the widest axis labels in the deck — otherwise <code>hv_ph_location()</code> warns that the plot chrome spills off the slide edge.</p>
+</section>
 </section>
 <section id="multi-panel-pdf-eda-batch-output" class="level2">
 <h2 class="anchored" data-anchor-id="multi-panel-pdf-eda-batch-output">Multi-panel PDF (EDA batch output)</h2>
 <p>When generating multiple plots in a loop, <code>patchwork::wrap_plots()</code> arranges them into a grid and <code>ggsave()</code> writes each page.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb18"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Build a list of plots (e.g. from an hv_eda() lapply loop)</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>plot_list <span class="ot">&lt;-</span> <span class="fu">lapply</span>(</span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">c</span>(<span class="st">"ef"</span>, <span class="st">"lv_mass"</span>, <span class="st">"peak_grad"</span>),</span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">function</span>(yv) {</span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    dta_eda <span class="ot">&lt;-</span> <span class="fu">sample_eda_data</span>()</span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">plot</span>(<span class="fu">hv_eda</span>(dta_eda, <span class="at">x_col =</span> <span class="st">"op_years"</span>, <span class="at">y_col =</span> yv,</span>
-<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a>                 <span class="at">y_label =</span> yv)) <span class="sc">+</span></span>
-<span id="cb18-8"><a href="#cb18-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">scale_colour_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
-<span id="cb18-9"><a href="#cb18-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>) <span class="sc">+</span></span>
-<span id="cb18-10"><a href="#cb18-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
-<span id="cb18-11"><a href="#cb18-11" aria-hidden="true" tabindex="-1"></a>  }</span>
-<span id="cb18-12"><a href="#cb18-12" aria-hidden="true" tabindex="-1"></a>)</span>
-<span id="cb18-13"><a href="#cb18-13" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb18-14"><a href="#cb18-14" aria-hidden="true" tabindex="-1"></a>per_page <span class="ot">&lt;-</span> <span class="dv">9</span>L</span>
-<span id="cb18-15"><a href="#cb18-15" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> (pg <span class="cf">in</span> <span class="fu">seq</span>(<span class="dv">1</span>, <span class="fu">length</span>(plot_list), <span class="at">by =</span> per_page)) {</span>
-<span id="cb18-16"><a href="#cb18-16" aria-hidden="true" tabindex="-1"></a>  idx     <span class="ot">&lt;-</span> <span class="fu">seq</span>(pg, <span class="fu">min</span>(pg <span class="sc">+</span> per_page <span class="sc">-</span> <span class="dv">1</span>L, <span class="fu">length</span>(plot_list)))</span>
-<span id="cb18-17"><a href="#cb18-17" aria-hidden="true" tabindex="-1"></a>  pg_plot <span class="ot">&lt;-</span> patchwork<span class="sc">::</span><span class="fu">wrap_plots</span>(plot_list[idx], <span class="at">nrow =</span> <span class="dv">3</span>, <span class="at">ncol =</span> <span class="dv">3</span>)</span>
-<span id="cb18-18"><a href="#cb18-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">ggsave</span>(</span>
-<span id="cb18-19"><a href="#cb18-19" aria-hidden="true" tabindex="-1"></a>    <span class="at">filename =</span> <span class="fu">sprintf</span>(here<span class="sc">::</span><span class="fu">here</span>(<span class="st">"graphs"</span>, <span class="st">"eda_page%02d.pdf"</span>),</span>
-<span id="cb18-20"><a href="#cb18-20" aria-hidden="true" tabindex="-1"></a>                       <span class="fu">ceiling</span>(pg <span class="sc">/</span> per_page)),</span>
-<span id="cb18-21"><a href="#cb18-21" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot     =</span> pg_plot,</span>
-<span id="cb18-22"><a href="#cb18-22" aria-hidden="true" tabindex="-1"></a>    <span class="at">width    =</span> <span class="dv">14</span>,</span>
-<span id="cb18-23"><a href="#cb18-23" aria-hidden="true" tabindex="-1"></a>    <span class="at">height   =</span> <span class="dv">14</span></span>
-<span id="cb18-24"><a href="#cb18-24" aria-hidden="true" tabindex="-1"></a>  )</span>
-<span id="cb18-25"><a href="#cb18-25" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb19"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Build a list of plots (e.g. from an hv_eda() lapply loop)</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>plot_list <span class="ot">&lt;-</span> <span class="fu">lapply</span>(</span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">c</span>(<span class="st">"ef"</span>, <span class="st">"lv_mass"</span>, <span class="st">"peak_grad"</span>),</span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">function</span>(yv) {</span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    dta_eda <span class="ot">&lt;-</span> <span class="fu">sample_eda_data</span>()</span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">plot</span>(<span class="fu">hv_eda</span>(dta_eda, <span class="at">x_col =</span> <span class="st">"op_years"</span>, <span class="at">y_col =</span> yv,</span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>                 <span class="at">y_label =</span> yv)) <span class="sc">+</span></span>
+<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>      <span class="fu">scale_colour_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
+<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>      <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>) <span class="sc">+</span></span>
+<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>      <span class="fu">theme_hv_poster</span>()</span>
+<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a>)</span>
+<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a>per_page <span class="ot">&lt;-</span> <span class="dv">9</span>L</span>
+<span id="cb19-15"><a href="#cb19-15" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> (pg <span class="cf">in</span> <span class="fu">seq</span>(<span class="dv">1</span>, <span class="fu">length</span>(plot_list), <span class="at">by =</span> per_page)) {</span>
+<span id="cb19-16"><a href="#cb19-16" aria-hidden="true" tabindex="-1"></a>  idx     <span class="ot">&lt;-</span> <span class="fu">seq</span>(pg, <span class="fu">min</span>(pg <span class="sc">+</span> per_page <span class="sc">-</span> <span class="dv">1</span>L, <span class="fu">length</span>(plot_list)))</span>
+<span id="cb19-17"><a href="#cb19-17" aria-hidden="true" tabindex="-1"></a>  pg_plot <span class="ot">&lt;-</span> patchwork<span class="sc">::</span><span class="fu">wrap_plots</span>(plot_list[idx], <span class="at">nrow =</span> <span class="dv">3</span>, <span class="at">ncol =</span> <span class="dv">3</span>)</span>
+<span id="cb19-18"><a href="#cb19-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">ggsave</span>(</span>
+<span id="cb19-19"><a href="#cb19-19" aria-hidden="true" tabindex="-1"></a>    <span class="at">filename =</span> <span class="fu">sprintf</span>(here<span class="sc">::</span><span class="fu">here</span>(<span class="st">"graphs"</span>, <span class="st">"eda_page%02d.pdf"</span>),</span>
+<span id="cb19-20"><a href="#cb19-20" aria-hidden="true" tabindex="-1"></a>                       <span class="fu">ceiling</span>(pg <span class="sc">/</span> per_page)),</span>
+<span id="cb19-21"><a href="#cb19-21" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot     =</span> pg_plot,</span>
+<span id="cb19-22"><a href="#cb19-22" aria-hidden="true" tabindex="-1"></a>    <span class="at">width    =</span> <span class="dv">14</span>,</span>
+<span id="cb19-23"><a href="#cb19-23" aria-hidden="true" tabindex="-1"></a>    <span class="at">height   =</span> <span class="dv">14</span></span>
+<span id="cb19-24"><a href="#cb19-24" aria-hidden="true" tabindex="-1"></a>  )</span>
+<span id="cb19-25"><a href="#cb19-25" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 </section>
 </section>
 <section id="legend-positioning" class="level1">
 <h1>Legend Positioning</h1>
-<p>ggplot2 places the legend outside the panel by default. For publication figures it is often cleaner to place it inside the panel or suppress it entirely.</p>
+<p>ggplot2 places the legend outside the panel by default. For publication figures we usually move it inside or drop it — the axis labels often do the identification work already.</p>
 <section id="inside-the-panel" class="level2">
 <h2 class="anchored" data-anchor-id="inside-the-panel">Inside the panel</h2>
 <p>Pass fractional coordinates <code>c(x, y)</code> to <code>legend.position</code> inside <code>theme()</code>. <code>c(0, 0)</code> is the bottom-left corner; <code>c(1, 1)</code> is the top-right.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb19"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="cn">NULL</span>) <span class="sc">+</span></span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="cn">NULL</span></span>
-<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb19-8"><a href="#cb19-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb19-9"><a href="#cb19-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb19-10"><a href="#cb19-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb19-11"><a href="#cb19-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.position  =</span> <span class="fu">c</span>(<span class="fl">0.15</span>, <span class="fl">0.2</span>),        <span class="co"># bottom-left of panel</span></span>
-<span id="cb19-12"><a href="#cb19-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.background =</span> <span class="fu">element_rect</span>(<span class="at">fill =</span> <span class="st">"white"</span>, <span class="at">colour =</span> <span class="st">"grey80"</span>,</span>
-<span id="cb19-13"><a href="#cb19-13" aria-hidden="true" tabindex="-1"></a>                                     <span class="at">linewidth =</span> <span class="fl">0.3</span>)</span>
-<span id="cb19-14"><a href="#cb19-14" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb20"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="cn">NULL</span>) <span class="sc">+</span></span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="cn">NULL</span></span>
+<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.position  =</span> <span class="fu">c</span>(<span class="fl">0.15</span>, <span class="fl">0.2</span>),        <span class="co"># bottom-left of panel</span></span>
+<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.background =</span> <span class="fu">element_rect</span>(<span class="at">fill =</span> <span class="st">"white"</span>, <span class="at">colour =</span> <span class="st">"grey80"</span>,</span>
+<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a>                                     <span class="at">linewidth =</span> <span class="fl">0.3</span>)</span>
+<span id="cb20-14"><a href="#cb20-14" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -676,19 +692,19 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="outside-the-panel-explicit-sides" class="level2">
 <h2 class="anchored" data-anchor-id="outside-the-panel-explicit-sides">Outside the panel (explicit sides)</h2>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb20"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
-<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
-<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
-<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb20-9"><a href="#cb20-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb20-10"><a href="#cb20-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb20-11"><a href="#cb20-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.position =</span> <span class="st">"bottom"</span>,             <span class="co"># "right" | "left" | "top" | "bottom"</span></span>
-<span id="cb20-12"><a href="#cb20-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.direction =</span> <span class="st">"horizontal"</span></span>
-<span id="cb20-13"><a href="#cb20-13" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb21"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
+<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
+<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
+<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb21-10"><a href="#cb21-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb21-11"><a href="#cb21-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.position =</span> <span class="st">"bottom"</span>,             <span class="co"># "right" | "left" | "top" | "bottom"</span></span>
+<span id="cb21-12"><a href="#cb21-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.direction =</span> <span class="st">"horizontal"</span></span>
+<span id="cb21-13"><a href="#cb21-13" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -701,15 +717,15 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="suppress-all-legends" class="level2">
 <h2 class="anchored" data-anchor-id="suppress-all-legends">Suppress all legends</h2>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb21"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km) <span class="sc">+</span></span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
-<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_manual</span>(<span class="at">values  =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
-<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>),</span>
-<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
-<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
-<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
-<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Freedom from Death (%)"</span>) <span class="sc">+</span></span>
-<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb22"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km) <span class="sc">+</span></span>
+<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
+<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_manual</span>(<span class="at">values  =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
+<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>),</span>
+<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
+<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
+<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
+<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Freedom from Death (%)"</span>) <span class="sc">+</span></span>
+<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -723,19 +739,19 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="legend-text-and-key-size" class="level2">
 <h2 class="anchored" data-anchor-id="legend-text-and-key-size">Legend text and key size</h2>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb22"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
-<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
-<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
-<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb22-11"><a href="#cb22-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.text  =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">9</span>),</span>
-<span id="cb22-12"><a href="#cb22-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.key.size =</span> <span class="fu">unit</span>(<span class="fl">0.4</span>, <span class="st">"cm"</span>)</span>
-<span id="cb22-13"><a href="#cb22-13" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb23"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
+<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
+<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
+<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.text  =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">9</span>),</span>
+<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">legend.key.size =</span> <span class="fu">unit</span>(<span class="fl">0.4</span>, <span class="st">"cm"</span>)</span>
+<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -748,23 +764,23 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="theme-overrides" class="level1">
 <h1>Theme Overrides</h1>
-<p><code>hv_theme()</code> sets a complete non-data formatting baseline. Layer additional <code>theme()</code> calls after it to adjust individual elements without touching the rest.</p>
+<p><code>theme_hv_manuscript()</code> sets a complete non-data formatting baseline. Layer additional <code>theme()</code> calls after it to adjust individual elements without touching the rest.</p>
 <section id="axis-text-size" class="level2">
 <h2 class="anchored" data-anchor-id="axis-text-size">Axis text size</h2>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb23"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
-<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
-<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
-<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb23-9"><a href="#cb23-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb23-10"><a href="#cb23-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb23-11"><a href="#cb23-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.text  =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">10</span>),   <span class="co"># tick labels</span></span>
-<span id="cb23-12"><a href="#cb23-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.title =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">12</span>)    <span class="co"># axis titles</span></span>
-<span id="cb23-13"><a href="#cb23-13" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb24"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
+<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
+<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
+<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.text  =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">10</span>),   <span class="co"># tick labels</span></span>
+<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.title =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">12</span>)    <span class="co"># axis titles</span></span>
+<span id="cb24-13"><a href="#cb24-13" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -777,18 +793,18 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="removing-minor-grid-lines" class="level2">
 <h2 class="anchored" data-anchor-id="removing-minor-grid-lines">Removing minor grid lines</h2>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb24"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
-<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
-<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb24-9"><a href="#cb24-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb24-10"><a href="#cb24-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb24-11"><a href="#cb24-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">panel.grid.minor =</span> <span class="fu">element_blank</span>()</span>
-<span id="cb24-12"><a href="#cb24-12" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb25"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
+<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb25-11"><a href="#cb25-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">panel.grid.minor =</span> <span class="fu">element_blank</span>()</span>
+<span id="cb25-12"><a href="#cb25-12" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -802,18 +818,18 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h2 class="anchored" data-anchor-id="rotating-x-axis-labels">Rotating x-axis labels</h2>
 <p>Useful for time-point labels or long category names.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb25"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
-<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb25-11"><a href="#cb25-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.text.x =</span> <span class="fu">element_text</span>(<span class="at">angle =</span> <span class="dv">45</span>, <span class="at">hjust =</span> <span class="dv">1</span>, <span class="at">vjust =</span> <span class="dv">1</span>)</span>
-<span id="cb25-12"><a href="#cb25-12" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb26"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
+<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.text.x =</span> <span class="fu">element_text</span>(<span class="at">angle =</span> <span class="dv">45</span>, <span class="at">hjust =</span> <span class="dv">1</span>, <span class="at">vjust =</span> <span class="dv">1</span>)</span>
+<span id="cb26-12"><a href="#cb26-12" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -827,24 +843,24 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h2 class="anchored" data-anchor-id="adding-a-plot-title-and-subtitle">Adding a plot title and subtitle</h2>
 <p>Titles are stripped from the base themes (they are rarely used in journal figures), but can be added back:</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb26"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km) <span class="sc">+</span></span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
-<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_manual</span>(<span class="at">values  =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>),</span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
-<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
-<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(</span>
-<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a>    <span class="at">title    =</span> <span class="st">"Overall Survival"</span>,</span>
-<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a>    <span class="at">subtitle =</span> <span class="fu">paste0</span>(<span class="st">"n = "</span>, <span class="fu">nrow</span>(dta_km), <span class="st">" patients"</span>),</span>
-<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">x        =</span> <span class="st">"Years after Operation"</span>,</span>
-<span id="cb26-12"><a href="#cb26-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">y        =</span> <span class="st">"Freedom from Death (%)"</span></span>
-<span id="cb26-13"><a href="#cb26-13" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb26-14"><a href="#cb26-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb26-15"><a href="#cb26-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb26-16"><a href="#cb26-16" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot.title    =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">14</span>, <span class="at">face =</span> <span class="st">"bold"</span>, <span class="at">hjust =</span> <span class="dv">0</span>),</span>
-<span id="cb26-17"><a href="#cb26-17" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot.subtitle =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">11</span>, <span class="at">colour =</span> <span class="st">"grey40"</span>, <span class="at">hjust =</span> <span class="dv">0</span>)</span>
-<span id="cb26-18"><a href="#cb26-18" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb27"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km) <span class="sc">+</span></span>
+<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
+<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_manual</span>(<span class="at">values  =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
+<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>),</span>
+<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
+<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
+<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
+<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(</span>
+<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>    <span class="at">title    =</span> <span class="st">"Overall Survival"</span>,</span>
+<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>    <span class="at">subtitle =</span> <span class="fu">paste0</span>(<span class="st">"n = "</span>, <span class="fu">nrow</span>(dta_km), <span class="st">" patients"</span>),</span>
+<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">x        =</span> <span class="st">"Years after Operation"</span>,</span>
+<span id="cb27-12"><a href="#cb27-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">y        =</span> <span class="st">"Freedom from Death (%)"</span></span>
+<span id="cb27-13"><a href="#cb27-13" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb27-14"><a href="#cb27-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb27-15"><a href="#cb27-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb27-16"><a href="#cb27-16" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot.title    =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">14</span>, <span class="at">face =</span> <span class="st">"bold"</span>, <span class="at">hjust =</span> <span class="dv">0</span>),</span>
+<span id="cb27-17"><a href="#cb27-17" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot.subtitle =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">11</span>, <span class="at">colour =</span> <span class="st">"grey40"</span>, <span class="at">hjust =</span> <span class="dv">0</span>)</span>
+<span id="cb27-18"><a href="#cb27-18" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -858,18 +874,18 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h2 class="anchored" data-anchor-id="expanding-plot-margins">Expanding plot margins</h2>
 <p>Add breathing room around the panel, for example when a figure is placed directly on a poster without a surrounding text frame.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb27"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
-<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
-<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb27-6"><a href="#cb27-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
-<span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb27-11"><a href="#cb27-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot.margin =</span> <span class="fu">margin</span>(<span class="at">t =</span> <span class="dv">10</span>, <span class="at">r =</span> <span class="dv">20</span>, <span class="at">b =</span> <span class="dv">10</span>, <span class="at">l =</span> <span class="dv">20</span>, <span class="at">unit =</span> <span class="st">"pt"</span>)</span>
-<span id="cb27-12"><a href="#cb27-12" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb28"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a>p_base <span class="sc">+</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
+<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb28-11"><a href="#cb28-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">plot.margin =</span> <span class="fu">margin</span>(<span class="at">t =</span> <span class="dv">10</span>, <span class="at">r =</span> <span class="dv">20</span>, <span class="at">b =</span> <span class="dv">10</span>, <span class="at">l =</span> <span class="dv">20</span>, <span class="at">unit =</span> <span class="st">"pt"</span>)</span>
+<span id="cb28-12"><a href="#cb28-12" aria-hidden="true" tabindex="-1"></a>  )</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -882,33 +898,33 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="multi-panel-figures-with-patchwork" class="level1">
 <h1>Multi-panel Figures with patchwork</h1>
-<p>The <code>patchwork</code> package composes multiple ggplot objects into a single figure. Use it to place two related plots side by side, or to stack a main plot above a companion table or risk panel.</p>
+<p>The <code>patchwork</code> package composes multiple ggplot objects into a single figure. The two patterns we reach for most are side-by-side comparisons and a main plot stacked above a companion table or risk panel.</p>
 <section id="side-by-side-plots" class="level2">
 <h2 class="anchored" data-anchor-id="side-by-side-plots">Side-by-side plots</h2>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb28"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(patchwork)</span>
-<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a>p_ms <span class="ot">&lt;-</span> p_base <span class="sc">+</span></span>
-<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
-<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
-<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
-<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
-<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
-<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
-<span id="cb28-11"><a href="#cb28-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
-<span id="cb28-12"><a href="#cb28-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-13"><a href="#cb28-13" aria-hidden="true" tabindex="-1"></a>p_km_ms <span class="ot">&lt;-</span> <span class="fu">plot</span>(km) <span class="sc">+</span></span>
-<span id="cb28-14"><a href="#cb28-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
-<span id="cb28-15"><a href="#cb28-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_manual</span>(<span class="at">values  =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
-<span id="cb28-16"><a href="#cb28-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>),</span>
-<span id="cb28-17"><a href="#cb28-17" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
-<span id="cb28-18"><a href="#cb28-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
-<span id="cb28-19"><a href="#cb28-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
-<span id="cb28-20"><a href="#cb28-20" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Freedom from Death (%)"</span>) <span class="sc">+</span></span>
-<span id="cb28-21"><a href="#cb28-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
-<span id="cb28-22"><a href="#cb28-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb28-23"><a href="#cb28-23" aria-hidden="true" tabindex="-1"></a>p_ms <span class="sc">|</span> p_km_ms</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb29"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(patchwork)</span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>p_ms <span class="ot">&lt;-</span> p_base <span class="sc">+</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_brewer</span>(<span class="at">palette =</span> <span class="st">"Set1"</span>, <span class="at">name =</span> <span class="st">"Group"</span>) <span class="sc">+</span></span>
+<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_shape_manual</span>(</span>
+<span id="cb29-6"><a href="#cb29-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">values =</span> <span class="fu">c</span>(<span class="st">"Group I"</span> <span class="ot">=</span> <span class="dv">15</span>, <span class="st">"Group II"</span> <span class="ot">=</span> <span class="dv">19</span>,</span>
+<span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>               <span class="st">"Group III"</span> <span class="ot">=</span> <span class="dv">17</span>, <span class="st">"Group IV"</span> <span class="ot">=</span> <span class="dv">18</span>),</span>
+<span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>    <span class="at">name =</span> <span class="st">"Group"</span></span>
+<span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Surgery Year"</span>, <span class="at">y =</span> <span class="st">"Outcome"</span>) <span class="sc">+</span></span>
+<span id="cb29-11"><a href="#cb29-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
+<span id="cb29-12"><a href="#cb29-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-13"><a href="#cb29-13" aria-hidden="true" tabindex="-1"></a>p_km_ms <span class="ot">&lt;-</span> <span class="fu">plot</span>(km) <span class="sc">+</span></span>
+<span id="cb29-14"><a href="#cb29-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_color_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
+<span id="cb29-15"><a href="#cb29-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_manual</span>(<span class="at">values  =</span> <span class="fu">c</span>(<span class="at">All =</span> <span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
+<span id="cb29-16"><a href="#cb29-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>),</span>
+<span id="cb29-17"><a href="#cb29-17" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
+<span id="cb29-18"><a href="#cb29-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
+<span id="cb29-19"><a href="#cb29-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
+<span id="cb29-20"><a href="#cb29-20" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Freedom from Death (%)"</span>) <span class="sc">+</span></span>
+<span id="cb29-21"><a href="#cb29-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
+<span id="cb29-22"><a href="#cb29-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb29-23"><a href="#cb29-23" aria-hidden="true" tabindex="-1"></a>p_ms <span class="sc">|</span> p_km_ms</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -922,8 +938,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="controlling-relative-widths-and-heights" class="level2">
 <h2 class="anchored" data-anchor-id="controlling-relative-widths-and-heights">Controlling relative widths and heights</h2>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb29"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a>(p_ms <span class="sc">|</span> p_km_ms) <span class="sc">+</span></span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_layout</span>(<span class="at">widths =</span> <span class="fu">c</span>(<span class="dv">2</span>, <span class="dv">1</span>))   <span class="co"># left panel twice as wide as right</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb30"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>(p_ms <span class="sc">|</span> p_km_ms) <span class="sc">+</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_layout</span>(<span class="at">widths =</span> <span class="fu">c</span>(<span class="dv">2</span>, <span class="dv">1</span>))   <span class="co"># left panel twice as wide as right</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -937,22 +953,22 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h2 class="anchored" data-anchor-id="stacking-a-plot-above-a-risk-table">Stacking a plot above a risk table</h2>
 <p>A common pattern with survival curves is to pair the plot with a numbers-at-risk panel. <code>hv_survival()</code> stores the risk table as a data frame at <code>km$tables$risk</code> — columns <code>strata</code>, <code>report_time</code>, <code>n.risk</code>. Build a ggplot text panel from it, then stack with <code>/</code>.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb30"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>risk_df <span class="ot">&lt;-</span> km<span class="sc">$</span>tables<span class="sc">$</span>risk</span>
-<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>rt_panel <span class="ot">&lt;-</span> <span class="fu">ggplot</span>(risk_df,</span>
-<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>                   <span class="fu">aes</span>(<span class="at">x =</span> report_time, <span class="at">y =</span> <span class="fu">factor</span>(strata),</span>
-<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>                       <span class="at">label =</span> n.risk)) <span class="sc">+</span></span>
-<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">geom_text</span>(<span class="at">size =</span> <span class="dv">3</span>) <span class="sc">+</span></span>
-<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
-<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="cn">NULL</span>) <span class="sc">+</span></span>
-<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>) <span class="sc">+</span></span>
-<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
-<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.line  =</span> <span class="fu">element_blank</span>(),</span>
-<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.ticks =</span> <span class="fu">element_blank</span>()</span>
-<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a>  )</span>
-<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a>p_km_ms <span class="sc">/</span> rt_panel <span class="sc">+</span></span>
-<span id="cb30-16"><a href="#cb30-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_layout</span>(<span class="at">heights =</span> <span class="fu">c</span>(<span class="dv">4</span>, <span class="dv">1</span>))</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb31"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a>risk_df <span class="ot">&lt;-</span> km<span class="sc">$</span>tables<span class="sc">$</span>risk</span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>rt_panel <span class="ot">&lt;-</span> <span class="fu">ggplot</span>(risk_df,</span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>                   <span class="fu">aes</span>(<span class="at">x =</span> report_time, <span class="at">y =</span> <span class="fu">factor</span>(strata),</span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>                       <span class="at">label =</span> n.risk)) <span class="sc">+</span></span>
+<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">geom_text</span>(<span class="at">size =</span> <span class="dv">3</span>) <span class="sc">+</span></span>
+<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">20</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">20</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
+<span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="cn">NULL</span>) <span class="sc">+</span></span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>() <span class="sc">+</span></span>
+<span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(</span>
+<span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.line  =</span> <span class="fu">element_blank</span>(),</span>
+<span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">axis.ticks =</span> <span class="fu">element_blank</span>()</span>
+<span id="cb31-13"><a href="#cb31-13" aria-hidden="true" tabindex="-1"></a>  )</span>
+<span id="cb31-14"><a href="#cb31-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-15"><a href="#cb31-15" aria-hidden="true" tabindex="-1"></a>p_km_ms <span class="sc">/</span> rt_panel <span class="sc">+</span></span>
+<span id="cb31-16"><a href="#cb31-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_layout</span>(<span class="at">heights =</span> <span class="fu">c</span>(<span class="dv">4</span>, <span class="dv">1</span>))</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -966,12 +982,12 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <h2 class="anchored" data-anchor-id="shared-axis-labels-and-panel-tags">Shared axis labels and panel tags</h2>
 <p><code>plot_annotation()</code> adds a shared title or tags (A, B, C…) across all panels.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb31"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a>(p_ms <span class="sc">|</span> p_km_ms) <span class="sc">+</span></span>
-<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_annotation</span>(</span>
-<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Figure 1. Outcomes after cardiac surgery"</span>,</span>
-<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">tag_levels =</span> <span class="st">"A"</span></span>
-<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">&amp;</span></span>
-<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(<span class="at">plot.tag =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">12</span>, <span class="at">face =</span> <span class="st">"bold"</span>))</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb32"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a>(p_ms <span class="sc">|</span> p_km_ms) <span class="sc">+</span></span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_annotation</span>(</span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Figure 1. Outcomes after cardiac surgery"</span>,</span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">tag_levels =</span> <span class="st">"A"</span></span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">&amp;</span></span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(<span class="at">plot.tag =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">12</span>, <span class="at">face =</span> <span class="st">"bold"</span>))</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -983,18 +999,18 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="saving-a-patchwork-composite" class="level2">
 <h2 class="anchored" data-anchor-id="saving-a-patchwork-composite">Saving a patchwork composite</h2>
-<p>Assign the composed object to a variable and pass it to <code>ggsave()</code>. For PowerPoint, save each panel individually with <code>save_ppt()</code> (patchwork composites are not editable DrawingML objects).</p>
+<p>Assign the composed object to a variable and pass it to <code>ggsave()</code>. For PowerPoint, save each panel individually with <code>save_ppt()</code> — patchwork flattens everything into a single raster, so the shapes and text are no longer editable in PowerPoint.</p>
 <div class="cell">
-<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb32"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a>combined <span class="ot">&lt;-</span> (p_ms <span class="sc">|</span> p_km_ms) <span class="sc">+</span></span>
-<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_annotation</span>(<span class="at">tag_levels =</span> <span class="st">"A"</span>) <span class="sc">&amp;</span></span>
-<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(<span class="at">plot.tag =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">12</span>, <span class="at">face =</span> <span class="st">"bold"</span>))</span>
-<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a><span class="fu">ggsave</span>(</span>
-<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">filename =</span> here<span class="sc">::</span><span class="fu">here</span>(<span class="st">"graphs"</span>, <span class="st">"fig1_combined.pdf"</span>),</span>
-<span id="cb32-7"><a href="#cb32-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">plot     =</span> combined,</span>
-<span id="cb32-8"><a href="#cb32-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">width    =</span> <span class="dv">14</span>,</span>
-<span id="cb32-9"><a href="#cb32-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">height   =</span> <span class="dv">7</span></span>
-<span id="cb32-10"><a href="#cb32-10" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb33"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a>combined <span class="ot">&lt;-</span> (p_ms <span class="sc">|</span> p_km_ms) <span class="sc">+</span></span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot_annotation</span>(<span class="at">tag_levels =</span> <span class="st">"A"</span>) <span class="sc">&amp;</span></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(<span class="at">plot.tag =</span> <span class="fu">element_text</span>(<span class="at">size =</span> <span class="dv">12</span>, <span class="at">face =</span> <span class="st">"bold"</span>))</span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a><span class="fu">ggsave</span>(</span>
+<span id="cb33-6"><a href="#cb33-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">filename =</span> here<span class="sc">::</span><span class="fu">here</span>(<span class="st">"graphs"</span>, <span class="st">"fig1_combined.pdf"</span>),</span>
+<span id="cb33-7"><a href="#cb33-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">plot     =</span> combined,</span>
+<span id="cb33-8"><a href="#cb33-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">width    =</span> <span class="dv">14</span>,</span>
+<span id="cb33-9"><a href="#cb33-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">height   =</span> <span class="dv">7</span></span>
+<span id="cb33-10"><a href="#cb33-10" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
 </section>
 </section>

--- a/vignettes/plot-decorators.qmd
+++ b/vignettes/plot-decorators.qmd
@@ -198,7 +198,7 @@ p_base +
 
 ## labs()
 
-`labs()` sets axis labels, legend title, subtitle, and caption text. We set
+`labs()` sets axis labels, the plot title, legend title, subtitle, and caption text. We set
 these outside the constructor so you can override them per project without
 touching the function itself.
 
@@ -221,7 +221,7 @@ plot(km) +
 
 ## annotate()
 
-`annotate()` places text, segments, or arrows at fixed data coordinates —
+`annotate()` places text, segments, rectangles, or arrows at fixed data coordinates —
 useful for a sample-size callout in the corner or a label pointing to an
 event of interest.
 

--- a/vignettes/plot-decorators.qmd
+++ b/vignettes/plot-decorators.qmd
@@ -37,8 +37,8 @@ library(hvtiPlotR)
 
 Every hvtiPlotR plot is built in two steps: a constructor (`hv_*()`) that
 shapes the data, followed by `plot()` that renders a bare `ggplot` object. No
-colour scales, axis labels, or theme are applied by either step. Decoration is
-added by chaining layers with `+`:
+colour scales, axis labels, or theme are applied by either step — you add those
+by chaining layers with `+`:
 
 ```
 plot(hv_*(...)) +
@@ -138,7 +138,7 @@ p_base +
 
 # Colour Scales
 
-`scale_colour_*` controls line and point colours; `scale_fill_*` controls filled areas (ribbons, bars). Both share the same `name` (legend title) and `guide` (legend display) arguments.
+`scale_colour_*` controls line and point colours; `scale_fill_*` controls filled areas (ribbons, bars). Both take the same `name` (legend title) and `guide` (legend display) arguments — set them once and both scales update.
 
 ## Manual colours
 
@@ -159,9 +159,10 @@ plot(km) +
 
 ## ColorBrewer palettes
 
-`scale_colour_brewer()` applies a ColorBrewer palette — safe, perceptually
-uniform, and print-friendly. Use `palette = "Set1"` for categorical data,
-`"RdYlGn"` for diverging, `"Blues"` for sequential.
+`scale_colour_brewer()` applies a ColorBrewer palette — perceptually uniform
+and print-safe, which matters when figures go to black-and-white PDF. Use
+`palette = "Set1"` for categorical data, `"RdYlGn"` for diverging, `"Blues"`
+for sequential.
 
 ```{r scale_colour_brewer}
 p_base +
@@ -177,8 +178,9 @@ p_base +
 
 ## Suppressing legends
 
-Pass `guide = "none"` to any scale to remove its legend entry. Use this when
-colour is self-evident from axis labels or annotations.
+Pass `guide = "none"` to any scale and that aesthetic drops out of the legend.
+You'd do this when the axis labels or an annotation already name the group —
+a redundant legend only takes up panel space.
 
 ```{r scale_no_legend}
 p_base +
@@ -196,9 +198,9 @@ p_base +
 
 ## labs()
 
-`labs()` sets the axis, legend, title, subtitle, and caption text. Set axis
-labels here rather than inside the plot function so they can be overridden per
-project.
+`labs()` sets axis labels, legend title, subtitle, and caption text. We set
+these outside the constructor so you can override them per project without
+touching the function itself.
 
 ```{r labs_example}
 plot(km) +
@@ -219,8 +221,9 @@ plot(km) +
 
 ## annotate()
 
-`annotate()` places text, segments, or rectangles at fixed data coordinates.
-Use it for sample size callouts, phase labels, or directional arrows.
+`annotate()` places text, segments, or arrows at fixed data coordinates —
+useful for a sample-size callout in the corner or a label pointing to an
+event of interest.
 
 ```{r annotate_example}
 plot(km) +
@@ -431,7 +434,8 @@ for (pg in seq(1, length(plot_list), by = per_page)) {
 # Legend Positioning
 
 ggplot2 places the legend outside the panel by default. For publication figures
-it is often cleaner to place it inside the panel or suppress it entirely.
+we usually move it inside or drop it — the axis labels often do the
+identification work already.
 
 ## Inside the panel
 
@@ -618,8 +622,8 @@ p_base +
 # Multi-panel Figures with patchwork
 
 The `patchwork` package composes multiple ggplot objects into a single figure.
-Use it to place two related plots side by side, or to stack a main plot above
-a companion table or risk panel.
+The two patterns we reach for most are side-by-side comparisons and a main
+plot stacked above a companion table or risk panel.
 
 ## Side-by-side plots
 
@@ -701,8 +705,9 @@ p_km_ms / rt_panel +
 ## Saving a patchwork composite
 
 Assign the composed object to a variable and pass it to `ggsave()`. For
-PowerPoint, save each panel individually with `save_ppt()` (patchwork composites
-are not editable DrawingML objects).
+PowerPoint, save each panel individually with `save_ppt()` — patchwork flattens
+everything into a single raster, so the shapes and text are no longer editable
+in PowerPoint.
 
 ```{r patchwork_save}
 #| eval: false

--- a/vignettes/plot-functions.html
+++ b/vignettes/plot-functions.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="John Ehrlinger ehrlinj@ccf.org">
-<meta name="dcterms.date" content="2026-05-21">
+<meta name="dcterms.date" content="2026-05-22">
 
 <title>hvtiPlotR Plot Functions</title>
 <style>
@@ -291,7 +291,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 21, 2026</p>
+      <p class="date">May 22, 2026</p>
     </div>
   </div>
   
@@ -315,7 +315,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb1-9"><a href="#cb1-9" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(ggplot2)</span>
 <span id="cb1-10"><a href="#cb1-10" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(hvtiPlotR)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </div>
-<p>All hvtiPlotR plot functions follow a two-step workflow. First, call the constructor (<code>hv_*()</code>) to validate and prepare data; this returns an S3 object of class <code>c("hv_&lt;concept&gt;", "hv_data")</code>. Then call <code>plot()</code> on that object to obtain a bare <code>ggplot</code> with no colour scales, axis labels, or theme applied. Compose those with the usual <code>+</code> operator. See the companion vignette “Decorating and Saving hvtiPlotR Plots” for full coverage of <code>scale_()</code>, <code>labs()</code>, <code>annotate()</code>, themes, and <code>ggsave()</code> patterns.</p>
+<p>All hvtiPlotR plot functions follow a two-step workflow. Call the constructor (<code>hv_*()</code>) to validate and prepare data — it returns an S3 object of class <code>c("hv_&lt;concept&gt;", "hv_data")</code> — then call <code>plot()</code> on the result to get a bare <code>ggplot</code> with no colour scales, axis labels, or theme applied yet. You add those with the usual <code>+</code> operator. See the companion vignette “Decorating and Saving hvtiPlotR Plots” for full coverage of <code>scale_()</code>, <code>labs()</code>, <code>annotate()</code>, themes, and <code>ggsave()</code> patterns.</p>
 <section id="template-reference-map" class="level1">
 <h1>Template Reference Map</h1>
 <p>The table below maps each hvtiPlotR constructor to the original SAS and R templates it ports. Functions marked with — have no direct predecessor and were designed specifically for this package. All functions have worked examples in the sections below.</p>
@@ -430,13 +430,9 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="mirrored-propensity-score-histogram" class="level1">
 <h1>Mirrored Propensity Score Histogram</h1>
-<p>A common figure in propensity-matched analyses is the mirrored histogram, which displays the propensity score distributions for two treatment groups before and after matching. The <strong>hvtiPlotR</strong> package provides the <code>hv_mirror_hist()</code> constructor to prepare the data, and <code>plot()</code> to render the figure.</p>
+<p>In propensity-matched analyses, we routinely produce a mirrored histogram to show how well matching compressed the overlap between two treatment groups. <code>hv_mirror_hist()</code> prepares the data; <code>plot()</code> hands you a bare ggplot to dress with colour and labels.</p>
 <p>The constructor accepts a data frame with columns for the propensity score, group indicator, and match indicator. The <code>sample_mirror_histogram_data()</code> function generates example data suitable for testing.</p>
-<p>Two display modes are selected by the arguments supplied to the constructor:</p>
-<ul>
-<li><strong>Binary-match mode</strong> (<code>match_col</code>): upper bars show all observations before matching; overlaid bars show the matched subset. This reproduces <code>tp.lp.mirror-histogram_SAVR-TF-TAVR.R</code>.</li>
-<li><strong>Weighted IPTW mode</strong> (<code>weight_col</code>): upper bars show raw counts; overlaid bars show per-bin IPTW weight sums. This reproduces <code>tp.lp.mirror_histo_before_after_wt.R</code>.</li>
-</ul>
+<p>Two display modes are selected by the arguments supplied to the constructor. <strong>Binary-match mode</strong> (<code>match_col</code>) reproduces <code>tp.lp.mirror-histogram_SAVR-TF-TAVR.R</code>: upper bars show all observations before matching; overlaid bars show the matched subset. <strong>Weighted IPTW mode</strong> (<code>weight_col</code>) reproduces <code>tp.lp.mirror_histo_before_after_wt.R</code>: upper bars show raw counts; overlaid bars show per-bin IPTW weight sums.</p>
 <section id="binary-match-mode-savr-vs.-tf-tavr" class="level2">
 <h2 class="anchored" data-anchor-id="binary-match-mode-savr-vs.-tf-tavr">Binary-match mode (SAVR vs.&nbsp;TF-TAVR)</h2>
 <div class="cell" data-caption="Mirrored Propensity Score Histogram — binary-match mode">
@@ -500,7 +496,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </div>
 </div>
 <p>The lighter bars show the full (pre-match) distribution for each group; the darker overlaid bars show the matched subset. Upper panel = first group label; lower panel = second group label. <code>scale_y_continuous(labels = abs)</code> converts the internal negative counts to positive labels. <code>y = Inf</code>/<code>-Inf</code> with <code>vjust</code> anchors each annotation near the panel edge regardless of data scale, so the positions adapt automatically to different dataset sizes.</p>
-<p>The constructor stores diagnostics with group counts and standardized mean differences (SMD) before and after matching in the <code>$tables$diagnostics</code> list:</p>
+<p>The constructor stores group counts and standardized mean differences (SMD) before and after matching in <code>$tables$diagnostics</code>. You can read those out directly:</p>
 <div class="cell" data-caption="Mirrored Histogram Diagnostics">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb5"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>mh<span class="sc">$</span>tables<span class="sc">$</span>diagnostics<span class="sc">$</span>smd_before</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output cell-output-stdout">
@@ -603,8 +599,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="stacked-histogram" class="level1">
 <h1>Stacked Histogram</h1>
-<p>A common exploratory figure is the stacked histogram, which shows how the composition of a numeric variable changes over time or across another grouping dimension. The <strong>hvtiPlotR</strong> package provides the <code>hv_stacked()</code> constructor and a <code>plot()</code> method to generate this figure.</p>
-<p><code>plot()</code> returns a bare <code>ggplot</code> object — no colour scales, axis labels, or theme are applied — so the caller can add those freely with the usual <code>+</code> operator.</p>
+<p>The stacked histogram shows how the composition of a numeric variable shifts over time or across a grouping dimension. <code>hv_stacked()</code> prepares the data; <code>plot()</code> hands you a bare ggplot to dress with colour and labels.</p>
 <p>The <code>sample_stacked_histogram_data()</code> function generates a reproducible example dataset with <code>year</code> and <code>category</code> columns.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb20"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Generate sample data</span></span>
@@ -691,8 +686,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="goodness-of-follow-up-plot" class="level1">
 <h1>Goodness-of-Follow-Up Plot</h1>
-<p>The goodness-of-follow-up plot is a standard quality-control figure in longitudinal outcome analyses. It displays each patient as a point at their operation date (x-axis) and follow-up duration (y-axis), with a short vertical tick below each point. A dashed diagonal line marks the maximum potential follow-up given the study start, study end, and follow-up closing date. The <strong>hvtiPlotR</strong> package provides the <code>hv_followup()</code> constructor and a <code>plot()</code> method to build this figure.</p>
-<p><code>plot()</code> returns a bare <code>ggplot</code> object with no colour, shape, axis, or label scales applied — those are added by the caller with standard <code>ggplot2</code> modifiers. The <code>type</code> argument selects the panel: <code>"followup"</code> (default, the death/censoring scatter) or <code>"event"</code> (competing non-fatal event panel).</p>
+<p>The goodness-of-follow-up plot is a standard quality-control figure in longitudinal outcome analyses. Each patient appears as a point at their operation date (x-axis) and follow-up duration (y-axis), with a short vertical tick below. A dashed diagonal line marks the maximum potential follow-up given the study start, study end, and follow-up closing date — points above the line have longer follow-up than that window alone explains, typically because passive surveillance supplemented active cross-sectional follow-up.</p>
+<p><code>hv_followup()</code> prepares the data; <code>plot()</code> hands you a bare ggplot with no colour, shape, axis, or label scales applied. Add those with the usual <code>+</code> operator. The <code>type</code> argument selects the panel: <code>"followup"</code> (default, the death/censoring scatter) or <code>"event"</code> (competing non-fatal event panel).</p>
 <section id="sample-data" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data">Sample data</h2>
 <div class="cell">
@@ -776,7 +771,6 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </div>
 </div>
 </div>
-<p>The diagonal dashed line represents the maximum potential follow-up. Points sitting above the line indicate patients with longer follow-up than expected from the study window, typically due to passive surveillance supplementing active cross-sectional follow-up.</p>
 </section>
 <section id="saving-1" class="level2">
 <h2 class="anchored" data-anchor-id="saving-1">Saving</h2>
@@ -842,8 +836,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </section>
 <section id="covariate-balance-plot" class="level1">
 <h1>Covariate Balance Plot</h1>
-<p>The covariate balance plot is the standard quality-control figure for propensity score matching and IPTW analyses. Each covariate occupies a labelled row; points show the standardized mean difference (SMD) for each comparison group (e.g.&nbsp;before and after matching). A solid vertical line marks zero balance; dotted vertical lines mark an imbalance threshold (default ±10%).</p>
-<p>The <strong>hvtiPlotR</strong> package provides <code>hv_balance()</code> to prepare data and <code>plot()</code> to render the figure, superseding <code>tp.lp.propen.cov_balance.R</code>. <code>plot()</code> returns a bare <code>ggplot</code> object — no colour, shape, axis labels, or theme applied — so all styling is added with the usual <code>+</code> operator.</p>
+<p>The covariate balance plot is the standard quality-control figure for propensity score matching and IPTW analyses. Each covariate occupies a labelled row; points show the standardized mean difference (SMD) for each comparison group (e.g.&nbsp;before and after matching). A solid vertical line marks zero balance; the dotted lines at ±10% give you a quick visual threshold for acceptable balance. <code>hv_balance()</code> prepares the data, superseding <code>tp.lp.propen.cov_balance.R</code>; <code>plot()</code> hands you a bare ggplot to style with the usual <code>+</code> operator.</p>
 <p>Input data must be in <strong>long format</strong>: one row per covariate × group combination with columns for the covariate name, the group label, and the numeric SMD value. When the source dataset arrives in wide format (one column per time-point, as the SAS export does), reshape it first:</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb32"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Simulate a wide-format export (e.g. from SAS or a summary table)</span></span>
@@ -1010,7 +1003,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="kaplan-meier-survival-curve" class="level1">
 <h1>Kaplan-Meier Survival Curve</h1>
-<p><code>hv_survival()</code> estimates the Kaplan-Meier product-limit survival function and stores all five companion plots’ data (matching the SAS <code>%kaplan</code> macro output <code>PLOTS</code>, <code>PLOTC</code>, <code>PLOTH</code>, <code>PLOTL</code>) plus tidy table data frames in the returned S3 object. Call <code>plot()</code> to render a bare ggplot for the selected <code>type</code> (default <code>"survival"</code>). Tidy tables are accessible via <code>$tables</code>. Confidence intervals use the logit transform with a default confidence level of 0.95.</p>
+<p><code>hv_survival()</code> estimates the Kaplan-Meier product-limit survival function and stores all five companion plots’ data (matching the SAS <code>%kaplan</code> macro output <code>PLOTS</code>, <code>PLOTC</code>, <code>PLOTH</code>, <code>PLOTL</code>) plus tidy summary tables in <code>$tables</code>. Call <code>plot()</code> with the <code>type</code> argument to render a bare ggplot for the selected panel (default <code>"survival"</code>). Confidence intervals use the logit transform at 0.95 by default.</p>
 <section id="sample-data-2" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-2">Sample data</h2>
 <div class="cell">
@@ -1185,7 +1178,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="hazard-rate-ploth1" class="level2">
 <h2 class="anchored" data-anchor-id="hazard-rate-ploth1">Hazard rate (PLOTH=1)</h2>
-<p>The raw point estimates are noisy; add <code>geom_smooth()</code> for a publication-ready smoothed hazard curve.</p>
+<p>The raw point estimates are noisy; add <code>geom_smooth()</code> for a smoothed curve suitable for figures.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb55"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb55-1"><a href="#cb55-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km, <span class="at">type =</span> <span class="st">"hazard"</span>) <span class="sc">+</span></span>
 <span id="cb55-2"><a href="#cb55-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">geom_smooth</span>(</span>
@@ -1229,13 +1222,8 @@ Age.After match                    Age  After match      3.5</code></pre>
 <section id="eda-barplots-and-scatterplots" class="level1">
 <h1>EDA Barplots and Scatterplots</h1>
 <p>The <strong>hvtiPlotR</strong> package provides <code>hv_eda()</code> for exploratory data analysis of all variables in a dataset against a reference time axis. It replicates the <code>Function_DataPlotting()</code> workflow from <code>tp.dp.EDA_barplots_scatterplots.R</code> and <code>tp.dp.EDA_barplots_scatterplots_varnames.R</code>, replacing base-R graphics with composable <code>ggplot2</code> objects.</p>
-<p>Three helper functions support the workflow:</p>
-<ul>
-<li><code>eda_classify_var()</code> — detects whether a column is continuous (<code>"Cont"</code>), numeric-categorical (<code>"Cat_Num"</code>), or character-categorical (<code>"Cat_Char"</code>), matching the <code>UniqueLimit</code> logic from the template.</li>
-<li><code>eda_select_vars()</code> — subsets and reorders columns by name or space-separated string, replacing the <code>Order_Variables()</code> / <code>Mod_Data &lt;- dta[, Order_Var]</code> pattern from the varnames template.</li>
-<li><code>sample_eda_data()</code> — generates a reproducible mixed-type dataset for demonstration.</li>
-</ul>
-<p><code>plot()</code> on an <code>hv_eda</code> object always returns a bare <code>ggplot</code>. Colour scales, axis labels, annotations, and <code>theme_hv_manuscript()</code> are added by the caller.</p>
+<p>Three helpers support the workflow: <code>eda_classify_var()</code> detects whether a column is continuous (<code>"Cont"</code>), numeric-categorical (<code>"Cat_Num"</code>), or character-categorical (<code>"Cat_Char"</code>) (matching the <code>UniqueLimit</code> logic from the template); <code>eda_select_vars()</code> subsets and reorders columns by name or space-separated string, replacing the <code>Order_Variables()</code> / <code>Mod_Data &lt;- dta[, Order_Var]</code> pattern from the varnames template; and <code>sample_eda_data()</code> generates a reproducible mixed-type dataset for demonstration.</p>
+<p><code>plot()</code> on an <code>hv_eda</code> object returns a bare <code>ggplot</code>. Add colour scales, axis labels, annotations, and <code>theme_hv_manuscript()</code>.</p>
 <section id="sample-data-3" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-3">Sample data</h2>
 <div class="cell">
@@ -1499,7 +1487,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="alluvial-sankey-plot" class="level1">
 <h1>Alluvial (Sankey) Plot</h1>
-<p><code>hv_alluvial()</code> prepares an alluvial (Sankey-style) diagram using <code>ggalluvial</code>. Each row of the input is a unique combination of axis values with an associated patient count; <code>plot()</code> draws flows proportional to that count. Ports <code>tp.dp.female_bicus_preAR_sankey.R</code>.</p>
+<p><code>hv_alluvial()</code> prepares an alluvial (Sankey-style) diagram using <code>ggalluvial</code>, so you can see how patients flow between states across time points or treatment stages. Each row of the input is a unique combination of axis values with an associated patient count; <code>plot()</code> draws flows proportional to that count. Ports <code>tp.dp.female_bicus_preAR_sankey.R</code>.</p>
 <section id="sample-data-4" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-4">Sample data</h2>
 <div class="cell">
@@ -1615,7 +1603,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="cluster-stability-sankey-plot" class="level1">
 <h1>Cluster Stability Sankey Plot</h1>
-<p><code>hv_sankey()</code> prepares a Sankey diagram showing how patients flow between labelled clusters as the number of clusters K increases. It ports the PAM cluster stability figure from the HVTI clustering analysis pipeline. Each column represents one value of K (default K = 2 to 9); each band shows the fraction of patients whose assignment changes between consecutive K values. Node labels show the cluster letter and count.</p>
+<p><code>hv_sankey()</code> prepares a Sankey diagram that lets you watch how patient cluster assignments shift as you increase K — a visual test of cluster stability. Where the bands stay wide and orderly, the solution holds; where they cross and fragment, you can see at a glance that K has grown past what the data supports. It ports the PAM cluster stability figure from the HVTI clustering analysis pipeline. Each column represents one value of K (default K = 2 to 9); each band shows the fraction of patients whose assignment changes between consecutive K values. Node labels show the cluster letter and count.</p>
 <p><strong>Requires <code>ggsankey</code></strong> (not on CRAN):</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb80"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb80-1"><a href="#cb80-1" aria-hidden="true" tabindex="-1"></a>remotes<span class="sc">::</span><span class="fu">install_github</span>(<span class="st">"davidsjoberg/ggsankey"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <section id="sample-data-5" class="level2">
@@ -1687,7 +1675,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="consort-patient-flow-diagram" class="level1">
 <h1>CONSORT Patient Flow Diagram</h1>
-<p><code>hv_consort()</code> builds a CONSORT-style patient-flow diagram. Unlike the other plot functions, the CONSORT API is <strong>three-step</strong> and does not use the <code>hv_data</code> class: build a patient-level <em>tracker</em> with <code>hv_consort_start()</code>, add one or more exclusion stages with <code>hv_consort_exclude()</code>, then render the diagram with <code>hv_consort()</code>. The diagram is drawn by the <code>consort</code> package (grid graphics), so it is not a <code>ggplot</code> and is not decorated with <code>+</code>.</p>
+<p><code>hv_consort()</code> builds a CONSORT-style patient-flow diagram via a <strong>three-step API</strong>: <code>hv_consort_start()</code> initializes a patient-level tracker, <code>hv_consort_exclude()</code> adds exclusion stages, and <code>hv_consort()</code> renders the result. Because the diagram is drawn by the <code>consort</code> package (grid graphics), it is not a <code>ggplot</code> and you don’t decorate it with <code>+</code>.</p>
 <section id="sample-data-6" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-6">Sample data</h2>
 <p>The quickest way to see a finished tracker is <code>sample_consort_data()</code>, which simulates a cardiac-surgery cohort and returns a three-stage <code>hv_consort_tracker</code>.</p>
@@ -1709,7 +1697,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="building-a-tracker-from-your-own-data" class="level2">
 <h2 class="anchored" data-anchor-id="building-a-tracker-from-your-own-data">Building a tracker from your own data</h2>
-<p>Start from a data frame with one row per patient. <code>hv_consort_start()</code> records the patient identifier and marks every patient as screened; each <code>hv_consort_exclude()</code> call adds an exclusion stage. Exclusion rules are two-sided formulas — <code>&lt;condition&gt; ~ "&lt;reason&gt;"</code> — evaluated against the data. The first matching rule wins, and patients already excluded upstream are gated out automatically, so each stage operates only on the survivors of the last.</p>
+<p>Start from a data frame with one row per patient. <code>hv_consort_start()</code> records the patient identifier and marks every patient as screened; each <code>hv_consort_exclude()</code> call adds an exclusion stage. Exclusion rules are two-sided formulas — <code>&lt;condition&gt; ~ "&lt;reason&gt;"</code> — evaluated against the data. The first matching rule wins, and patients dropped in an earlier stage are automatically skipped in later ones, so each stage operates only on the survivors of the last.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb91"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb91-1"><a href="#cb91-1" aria-hidden="true" tabindex="-1"></a><span class="fu">set.seed</span>(<span class="dv">42</span>)</span>
 <span id="cb91-2"><a href="#cb91-2" aria-hidden="true" tabindex="-1"></a>cohort <span class="ot">&lt;-</span> <span class="fu">data.frame</span>(</span>
@@ -1801,7 +1789,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="hazard-plot" class="level1">
 <h1>Hazard Plot</h1>
-<p><code>hazard_plot()</code> plots pre-computed parametric survival, hazard, or cumulative-hazard curves from a fitted Weibull (or other parametric) model, with optional Kaplan-Meier empirical overlay and population life-table reference. It ports the entire <code>tp.hp.dead.*</code> SAS template family.</p>
+<p><code>hazard_plot()</code> plots pre-computed parametric curves — survival, hazard, or cumulative hazard — from a fitted Weibull or other parametric model, with optional Kaplan-Meier empirical overlay and population life-table reference. It ports the entire <code>tp.hp.dead.*</code> SAS template family.</p>
 <p>The input data comes from two sources that map directly to the SAS output:</p>
 <table class="caption-top table">
 <colgroup>
@@ -2150,7 +2138,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="nnt-curve" class="level2">
 <h2 class="anchored" data-anchor-id="nnt-curve">NNT curve</h2>
-<p>NNT decreases over time as the treatment benefit accumulates.</p>
+<p>NNT decreases over time as the treatment benefit accumulates — early in follow-up you need to treat many patients to prevent one event; by later years the survival gap has widened enough that fewer do.</p>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb114"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="fu">nnt_plot</span>(</span>
 <span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a>  nnt_dat,</span>
@@ -2263,7 +2251,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </tr>
 </tbody>
 </table>
-<p>The constructor accepts patient-level data and computes annual summaries (mean or median) internally. <code>plot()</code> returns a bare ggplot. Compose with <code>scale_colour_*</code>, <code>scale_shape_*</code>, <code>scale_x_continuous()</code>, <code>scale_y_continuous()</code>, <code>coord_cartesian()</code>, <code>labs()</code>, <code>annotate()</code>, and <code>theme_hv_manuscript()</code>.</p>
+<p>The constructor accepts patient-level data and computes annual summaries (mean or median) internally. <code>plot()</code> returns a bare ggplot; add scales, labels, annotations, and <code>theme_hv_manuscript()</code>.</p>
 <section id="sample-data-10" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-10">Sample data</h2>
 <div class="cell">
@@ -2623,8 +2611,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="spaghetti-profile-plot" class="level1">
 <h1>Spaghetti / Profile Plot</h1>
-<p><code>hv_spaghetti()</code> ports the pattern from <code>tp.dp.spaghetti.echo.R</code>: one trajectory line per subject over time, with optional stratification by a grouping variable. <code>plot()</code> accepts <code>add_smooth = TRUE</code> for an optional LOESS overlay. The original template covers nine figures — unstratified and sex-stratified variants of three echo outcomes (AV mean gradient, AV area, DVI) plus an ordinal MV regurgitation grade plot.</p>
-<p><code>plot()</code> returns a bare ggplot. Compose with <code>scale_colour_manual()</code>, <code>scale_x_continuous()</code>, <code>scale_y_continuous()</code>, <code>coord_cartesian()</code>, <code>labs()</code>, and <code>theme_hv_manuscript()</code>.</p>
+<p><code>hv_spaghetti()</code> ports the pattern from <code>tp.dp.spaghetti.echo.R</code>: one trajectory line per subject over time, with optional stratification by a grouping variable. <code>plot()</code> accepts <code>add_smooth = TRUE</code> for an optional LOESS overlay and returns a bare ggplot you can dress with <code>theme_hv_manuscript()</code>. The original template covers nine figures — unstratified and sex-stratified variants of three echo outcomes (AV mean gradient, AV area, DVI) plus an ordinal MV regurgitation grade plot.</p>
 <section id="sample-data-11" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-11">Sample data</h2>
 <div class="cell">
@@ -2835,7 +2822,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 <section id="nonparametric-temporal-trend-curve" class="level1">
 <h1>Nonparametric Temporal Trend Curve</h1>
 <p><code>hv_nonparametric()</code> prepares pre-computed average curves from a two-phase nonparametric temporal trend model — the R equivalent of the SAS <code>tp.np.*.avrg_curv.*</code> and <code>tp.np.*.u.trend.*</code> template family.</p>
-<p>The constructor accepts the SAS <code>mean_curv</code> / <code>boots_ci</code> datasets exported to CSV and read in with <code>read.csv()</code>. <code>plot()</code> returns a bare ggplot for composition with <code>scale_colour_*</code>, <code>labs()</code>, and <code>theme_hv_manuscript()</code>.</p>
+<p>Pass the SAS <code>mean_curv</code> and <code>boots_ci</code> datasets (read in with <code>read.csv()</code>) and call <code>plot()</code> for a bare ggplot you can dress with colour, labels, and <code>theme_hv_manuscript()</code>.</p>
 <section id="sample-data-12" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-12">Sample data</h2>
 <div class="cell">
@@ -2979,7 +2966,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 <section id="nonparametric-ordinal-outcome-curve" class="level1">
 <h1>Nonparametric Ordinal Outcome Curve</h1>
 <p><code>hv_ordinal()</code> prepares pre-computed grade-specific probability curves from a cumulative proportional-odds model — the R equivalent of <code>tp.np.*.ordinal.*</code> SAS templates (e.g.&nbsp;TR grade prevalence, AR severity).</p>
-<p>The SAS <code>predict</code> dataset stores one column per grade (<code>p0</code>, <code>p1</code>, <code>p2</code>, <code>p3</code>). Before calling this function, reshape it from wide to long format:</p>
+<p>The SAS <code>predict</code> dataset stores one column per grade (<code>p0</code>, <code>p1</code>, <code>p2</code>, <code>p3</code>). You’ll need to reshape it to long format before passing it to the constructor:</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb152"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(tidyr)</span>
 <span id="cb152-2"><a href="#cb152-2" aria-hidden="true" tabindex="-1"></a>long <span class="ot">&lt;-</span> <span class="fu">pivot_longer</span>(</span>
 <span id="cb152-3"><a href="#cb152-3" aria-hidden="true" tabindex="-1"></a>  predict_wide,</span>
@@ -3118,7 +3105,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 <section id="longitudinal-participation-counts" class="level1">
 <h1>Longitudinal Participation Counts</h1>
 <p><code>hv_longitudinal()</code> reproduces the two-panel layout from <code>tp.dp.longitudinal_patients_measures.*</code>: a grouped bar chart of patients and measurements at each follow-up window, paired with a numeric summary table below. Call <code>plot(lc)</code> for the bar chart and <code>plot(lc, type = "table")</code> for the table panel. Compose the two panels with <code>patchwork</code>.</p>
-<p>Input is <strong>pre-aggregated long-format data</strong> — one row per (time window, series) combination. Use <code>sample_longitudinal_counts_data()</code> to derive this from patient-level data, or build it yourself from your registry data.</p>
+<p>Input must be <strong>pre-aggregated long-format data</strong> (one row per time-window × series combination). Use <code>sample_longitudinal_counts_data()</code> to derive this from patient-level data, or build it yourself from your registry data.</p>
 <section id="sample-data-14" class="level2">
 <h2 class="anchored" data-anchor-id="sample-data-14">Sample data</h2>
 <div class="cell">
@@ -3240,7 +3227,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="upset-plot" class="level1">
 <h1>UpSet Plot</h1>
-<p><code>hv_upset()</code> builds an UpSet diagram via <code>ggupset::scale_x_upset()</code> to visualise surgical procedure co-occurrences or any set membership data. Unlike Venn diagrams, UpSet plots scale to many sets cleanly.</p>
+<p><code>hv_upset()</code> builds an UpSet diagram via <code>ggupset::scale_x_upset()</code> to visualise surgical procedure co-occurrences or any set membership data. Where a Venn diagram breaks down past three or four sets, UpSet scales cleanly to seven or more.</p>
 <p><code>plot.hv_upset()</code> returns a <strong>ggplot</strong> when <code>set_size = FALSE</code>, or a <strong>patchwork composite</strong> of an intersection-bar plot + a set-size sidebar when <code>set_size = TRUE</code> (the default). For the bare ggplot path, themes apply via <code>+</code> like every other hvtiPlotR plot; for the patchwork path, use patchwork’s <code>&amp;</code> operator to theme every sub-panel:</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb168"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(hu) <span class="sc">&amp;</span> <span class="fu">theme_hv_poster</span>()                  <span class="co"># default (patchwork)</span></span>
 <span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(hu, <span class="at">set_size =</span> <span class="cn">FALSE</span>) <span class="sc">+</span> <span class="fu">theme_hv_poster</span>() <span class="co"># single ggplot</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
@@ -3339,7 +3326,7 @@ Age.After match                    Age  After match      3.5</code></pre>
 </section>
 <section id="draft-footnotes" class="level1">
 <h1>Draft Footnotes</h1>
-<p><code>make_footnote()</code> writes a small annotation to the <strong>bottom-right corner</strong> of the current graphics device using grid. Call it <em>after</em> printing a plot to mark the figure as a work-in-progress during analysis. For publication-ready output, simply omit the call — the plot itself is unchanged.</p>
+<p><code>make_footnote()</code> writes a small annotation to the <strong>bottom-right corner</strong> of the current graphics device using grid. Call it <em>after</em> printing a plot to mark the figure as a work-in-progress during analysis. When you’re ready for final output, omit the call — the plot object itself is untouched.</p>
 <pre><code># During analysis                   # For publication
 print(p)                             ggsave("fig1.pdf", p, ...)
 make_footnote("R/analysis.R")        # &lt;- no footnote call</code></pre>

--- a/vignettes/plot-functions.qmd
+++ b/vignettes/plot-functions.qmd
@@ -33,13 +33,14 @@ library(ggplot2)
 library(hvtiPlotR)
 ```
 
-All hvtiPlotR plot functions follow a two-step workflow. First, call the
-constructor (`hv_*()`) to validate and prepare data; this returns an S3
-object of class `c("hv_<concept>", "hv_data")`. Then call `plot()` on that
-object to obtain a bare `ggplot` with no colour scales, axis labels, or theme
-applied. Compose those with the usual `+` operator. See the companion vignette
-"Decorating and Saving hvtiPlotR Plots" for full coverage of `scale_()`,
-`labs()`, `annotate()`, themes, and `ggsave()` patterns.
+All hvtiPlotR plot functions follow a two-step workflow. Call the
+constructor (`hv_*()`) to validate and prepare data — it returns an S3
+object of class `c("hv_<concept>", "hv_data")` — then call `plot()` on
+the result to get a bare `ggplot` with no colour scales, axis labels, or
+theme applied yet. You add those with the usual `+` operator. See the
+companion vignette "Decorating and Saving hvtiPlotR Plots" for full
+coverage of `scale_()`, `labs()`, `annotate()`, themes, and `ggsave()`
+patterns.
 
 # Template Reference Map
 
@@ -76,14 +77,19 @@ the legacy single-call API pending migration to the two-step constructor pattern
 
 # Mirrored Propensity Score Histogram
 
-A common figure in propensity-matched analyses is the mirrored histogram, which displays the propensity score distributions for two treatment groups before and after matching. The **hvtiPlotR** package provides the `hv_mirror_hist()` constructor to prepare the data, and `plot()` to render the figure.
+In propensity-matched analyses, we routinely produce a mirrored histogram
+to show how well matching compressed the overlap between two treatment
+groups. `hv_mirror_hist()` prepares the data; `plot()` hands you a bare
+ggplot to dress with colour and labels.
 
 The constructor accepts a data frame with columns for the propensity score, group indicator, and match indicator. The `sample_mirror_histogram_data()` function generates example data suitable for testing.
 
-Two display modes are selected by the arguments supplied to the constructor:
-
-- **Binary-match mode** (`match_col`): upper bars show all observations before matching; overlaid bars show the matched subset. This reproduces `tp.lp.mirror-histogram_SAVR-TF-TAVR.R`.
-- **Weighted IPTW mode** (`weight_col`): upper bars show raw counts; overlaid bars show per-bin IPTW weight sums. This reproduces `tp.lp.mirror_histo_before_after_wt.R`.
+Two display modes are selected by the arguments supplied to the constructor.
+**Binary-match mode** (`match_col`) reproduces `tp.lp.mirror-histogram_SAVR-TF-TAVR.R`:
+upper bars show all observations before matching; overlaid bars show the
+matched subset. **Weighted IPTW mode** (`weight_col`) reproduces
+`tp.lp.mirror_histo_before_after_wt.R`: upper bars show raw counts;
+overlaid bars show per-bin IPTW weight sums.
 
 ## Binary-match mode (SAVR vs. TF-TAVR)
 
@@ -140,7 +146,7 @@ p +
 
 The lighter bars show the full (pre-match) distribution for each group; the darker overlaid bars show the matched subset. Upper panel = first group label; lower panel = second group label. `scale_y_continuous(labels = abs)` converts the internal negative counts to positive labels. `y = Inf`/`-Inf` with `vjust` anchors each annotation near the panel edge regardless of data scale, so the positions adapt automatically to different dataset sizes.
 
-The constructor stores diagnostics with group counts and standardized mean differences (SMD) before and after matching in the `$tables$diagnostics` list:
+The constructor stores group counts and standardized mean differences (SMD) before and after matching in `$tables$diagnostics`. You can read those out directly:
 
 ```{r}
 #| label: mirror_histogram_diagnostics
@@ -215,9 +221,9 @@ mh_wt$tables$diagnostics$effective_n_by_group
 
 # Stacked Histogram
 
-A common exploratory figure is the stacked histogram, which shows how the composition of a numeric variable changes over time or across another grouping dimension. The **hvtiPlotR** package provides the `hv_stacked()` constructor and a `plot()` method to generate this figure.
-
-`plot()` returns a bare `ggplot` object — no colour scales, axis labels, or theme are applied — so the caller can add those freely with the usual `+` operator.
+The stacked histogram shows how the composition of a numeric variable
+shifts over time or across a grouping dimension. `hv_stacked()` prepares
+the data; `plot()` hands you a bare ggplot to dress with colour and labels.
 
 The `sample_stacked_histogram_data()` function generates a reproducible example dataset with `year` and `category` columns.
 
@@ -291,17 +297,19 @@ ggsave(
 # Goodness-of-Follow-Up Plot
 
 The goodness-of-follow-up plot is a standard quality-control figure in
-longitudinal outcome analyses. It displays each patient as a point at their
-operation date (x-axis) and follow-up duration (y-axis), with a short vertical
-tick below each point. A dashed diagonal line marks the maximum potential
-follow-up given the study start, study end, and follow-up closing date. The
-**hvtiPlotR** package provides the `hv_followup()` constructor and a `plot()`
-method to build this figure.
+longitudinal outcome analyses. Each patient appears as a point at their
+operation date (x-axis) and follow-up duration (y-axis), with a short
+vertical tick below. A dashed diagonal line marks the maximum potential
+follow-up given the study start, study end, and follow-up closing date —
+points above the line have longer follow-up than that window alone
+explains, typically because passive surveillance supplemented active
+cross-sectional follow-up.
 
-`plot()` returns a bare `ggplot` object with no colour, shape, axis, or label
-scales applied — those are added by the caller with standard `ggplot2`
-modifiers. The `type` argument selects the panel: `"followup"` (default, the
-death/censoring scatter) or `"event"` (competing non-fatal event panel).
+`hv_followup()` prepares the data; `plot()` hands you a bare ggplot with
+no colour, shape, axis, or label scales applied. Add those with the usual
+`+` operator. The `type` argument selects the panel: `"followup"`
+(default, the death/censoring scatter) or `"event"` (competing non-fatal
+event panel).
 
 ## Sample data
 
@@ -370,11 +378,6 @@ gfup_final <- plot(gf, alpha = 0.8) +
 
 gfup_final
 ```
-
-The diagonal dashed line represents the maximum potential follow-up. Points
-sitting above the line indicate patients with longer follow-up than expected
-from the study window, typically due to passive surveillance supplementing
-active cross-sectional follow-up.
 
 ## Saving
 
@@ -446,13 +449,11 @@ share the same diagonal reference line and can be saved individually with `ggsav
 The covariate balance plot is the standard quality-control figure for
 propensity score matching and IPTW analyses. Each covariate occupies a
 labelled row; points show the standardized mean difference (SMD) for each
-comparison group (e.g. before and after matching). A solid vertical line marks
-zero balance; dotted vertical lines mark an imbalance threshold (default ±10%).
-
-The **hvtiPlotR** package provides `hv_balance()` to prepare data and
-`plot()` to render the figure, superseding `tp.lp.propen.cov_balance.R`.
-`plot()` returns a bare `ggplot` object — no colour, shape, axis labels, or
-theme applied — so all styling is added with the usual `+` operator.
+comparison group (e.g. before and after matching). A solid vertical line
+marks zero balance; the dotted lines at ±10% give you a quick visual
+threshold for acceptable balance. `hv_balance()` prepares the data,
+superseding `tp.lp.propen.cov_balance.R`; `plot()` hands you a bare
+ggplot to style with the usual `+` operator.
 
 Input data must be in **long format**: one row per covariate × group
 combination with columns for the covariate name, the group label, and the
@@ -595,11 +596,10 @@ ggsave(
 
 `hv_survival()` estimates the Kaplan-Meier product-limit survival function
 and stores all five companion plots' data (matching the SAS `%kaplan` macro
-output `PLOTS`, `PLOTC`, `PLOTH`, `PLOTL`) plus tidy table data frames in the
-returned S3 object. Call `plot()` to render a bare ggplot for the selected
-`type` (default `"survival"`). Tidy tables are accessible via `$tables`.
-Confidence intervals use the logit transform with a default confidence level
-of 0.95.
+output `PLOTS`, `PLOTC`, `PLOTH`, `PLOTL`) plus tidy summary tables in
+`$tables`. Call `plot()` with the `type` argument to render a bare ggplot
+for the selected panel (default `"survival"`). Confidence intervals use
+the logit transform at 0.95 by default.
 
 ## Sample data
 
@@ -724,8 +724,8 @@ plot(km_s, type = "loglog") +
 
 ## Hazard rate (PLOTH=1)
 
-The raw point estimates are noisy; add `geom_smooth()` for a publication-ready
-smoothed hazard curve.
+The raw point estimates are noisy; add `geom_smooth()` for a smoothed
+curve suitable for figures.
 
 ```{r}
 #| label: km_hazard
@@ -762,19 +762,16 @@ of all variables in a dataset against a reference time axis. It replicates the
 and `tp.dp.EDA_barplots_scatterplots_varnames.R`, replacing base-R graphics
 with composable `ggplot2` objects.
 
-Three helper functions support the workflow:
+Three helpers support the workflow: `eda_classify_var()` detects whether a
+column is continuous, numeric-categorical, or character-categorical (matching
+the `UniqueLimit` logic from the template); `eda_select_vars()` subsets and
+reorders columns by name or space-separated string, replacing the
+`Order_Variables()` / `Mod_Data <- dta[, Order_Var]` pattern from the varnames
+template; and `sample_eda_data()` generates a reproducible mixed-type dataset
+for demonstration.
 
-- `eda_classify_var()` — detects whether a column is continuous (`"Cont"`),
-  numeric-categorical (`"Cat_Num"`), or character-categorical (`"Cat_Char"`),
-  matching the `UniqueLimit` logic from the template.
-- `eda_select_vars()` — subsets and reorders columns by name or
-  space-separated string, replacing the `Order_Variables()` /
-  `Mod_Data <- dta[, Order_Var]` pattern from the varnames template.
-- `sample_eda_data()` — generates a reproducible mixed-type dataset for
-  demonstration.
-
-`plot()` on an `hv_eda` object always returns a bare `ggplot`. Colour scales,
-axis labels, annotations, and `theme_hv_manuscript()` are added by the caller.
+`plot()` on an `hv_eda` object returns a bare `ggplot`. Add colour scales,
+axis labels, annotations, and a theme the usual way.
 
 ## Sample data
 
@@ -967,9 +964,11 @@ for (pg in seq(1, length(all_plots), by = per_page)) {
 # Alluvial (Sankey) Plot
 
 `hv_alluvial()` prepares an alluvial (Sankey-style) diagram using
-`ggalluvial`. Each row of the input is a unique combination of axis values
-with an associated patient count; `plot()` draws flows proportional to that
-count. Ports `tp.dp.female_bicus_preAR_sankey.R`.
+`ggalluvial`, so you can see how patients flow between states across
+time points or treatment stages. Each row of the input is a unique
+combination of axis values with an associated patient count; `plot()`
+draws flows proportional to that count. Ports
+`tp.dp.female_bicus_preAR_sankey.R`.
 
 ## Sample data
 
@@ -1061,12 +1060,15 @@ ggsave("../graphs/alluvial.pdf", p_al, width = 8, height = 6)
 
 # Cluster Stability Sankey Plot
 
-`hv_sankey()` prepares a Sankey diagram showing how patients flow between
-labelled clusters as the number of clusters K increases. It ports the PAM
-cluster stability figure from the HVTI clustering analysis pipeline. Each
-column represents one value of K (default K = 2 to 9); each band shows the
-fraction of patients whose assignment changes between consecutive K values. Node
-labels show the cluster letter and count.
+`hv_sankey()` prepares a Sankey diagram that lets you watch how patient
+cluster assignments shift as you increase K — a visual test of cluster
+stability. Where the bands stay wide and orderly, the solution holds; where
+they cross and fragment, you can see at a glance that K has grown past what
+the data supports. It ports the PAM cluster stability figure from the HVTI
+clustering analysis pipeline. Each column represents one value of K (default
+K = 2 to 9); each band shows the fraction of patients whose assignment
+changes between consecutive K values. Node labels show the cluster letter
+and count.
 
 **Requires `ggsankey`** (not on CRAN):
 ```r
@@ -1145,12 +1147,11 @@ ggsave("../graphs/sankey_clusters.pdf", p_san, width = 8, height = 5)
 
 # CONSORT Patient Flow Diagram
 
-`hv_consort()` builds a CONSORT-style patient-flow diagram. Unlike the other
-plot functions, the CONSORT API is **three-step** and does not use the
-`hv_data` class: build a patient-level *tracker* with `hv_consort_start()`,
-add one or more exclusion stages with `hv_consort_exclude()`, then render the
-diagram with `hv_consort()`. The diagram is drawn by the `consort` package
-(grid graphics), so it is not a `ggplot` and is not decorated with `+`.
+`hv_consort()` builds a CONSORT-style patient-flow diagram via a
+**three-step API**: `hv_consort_start()` initializes a patient-level
+tracker, `hv_consort_exclude()` adds exclusion stages, and `hv_consort()`
+renders the result. Because the diagram is drawn by the `consort` package
+(grid graphics), it is not a `ggplot` and you don't decorate it with `+`.
 
 ## Sample data
 
@@ -1166,12 +1167,13 @@ tracker
 
 ## Building a tracker from your own data
 
-Start from a data frame with one row per patient. `hv_consort_start()` records
-the patient identifier and marks every patient as screened; each
+Start from a data frame with one row per patient. `hv_consort_start()`
+records the patient identifier and marks every patient as screened; each
 `hv_consort_exclude()` call adds an exclusion stage. Exclusion rules are
-two-sided formulas — `<condition> ~ "<reason>"` — evaluated against the data.
-The first matching rule wins, and patients already excluded upstream are gated
-out automatically, so each stage operates only on the survivors of the last.
+two-sided formulas — `<condition> ~ "<reason>"` — evaluated against the
+data. The first matching rule wins, and patients dropped in an earlier
+stage are automatically skipped in later ones, so each stage operates only
+on the survivors of the last.
 
 ```{r}
 #| label: consort_build
@@ -1252,8 +1254,8 @@ save_ppt(
 
 # Hazard Plot
 
-`hazard_plot()` plots pre-computed parametric survival, hazard, or
-cumulative-hazard curves from a fitted Weibull (or other parametric) model,
+`hazard_plot()` plots pre-computed parametric curves — survival, hazard,
+or cumulative hazard — from a fitted Weibull or other parametric model,
 with optional Kaplan-Meier empirical overlay and population life-table
 reference. It ports the entire `tp.hp.dead.*` SAS template family.
 
@@ -1525,7 +1527,9 @@ head(nnt_dat)
 
 ## NNT curve
 
-NNT decreases over time as the treatment benefit accumulates.
+NNT decreases over time as the treatment benefit accumulates — early in
+follow-up you need to treat many patients to prevent one event; by later
+years the survival gap has widened enough that fewer do.
 
 ```{r}
 #| label: nnt_curve
@@ -1597,11 +1601,9 @@ ggsave("../graphs/hazard_survival.pdf", p_hp, width = 11.5, height = 8)
 | `tp.lp.trends.polytomous.sas` | Tricuspid valve repair, 1990–1999 | Polytomous (≥3) groups, x 1990–1999 by 1 |
 | `tp.dp.trends.R` | Mitral degeneration, 1985–2015 | NYHA %, LV mass, %CHF, case volume, LOS |
 
-The constructor accepts patient-level data and computes annual summaries (mean
-or median) internally. `plot()` returns a bare ggplot. Compose with
-`scale_colour_*`, `scale_shape_*`, `scale_x_continuous()`,
-`scale_y_continuous()`, `coord_cartesian()`, `labs()`, `annotate()`, and
-`theme_hv_manuscript()`.
+The constructor accepts patient-level data and computes annual summaries
+(mean or median) internally. `plot()` returns a bare ggplot; add scales,
+labels, annotations, and a theme the usual way.
 
 ## Sample data
 
@@ -1902,14 +1904,11 @@ ggsave(here::here("graphs", "rp.trends.pdf"), p_tr, width = 11.5, height = 8)
 
 `hv_spaghetti()` ports the pattern from `tp.dp.spaghetti.echo.R`: one
 trajectory line per subject over time, with optional stratification by a
-grouping variable. `plot()` accepts `add_smooth = TRUE` for an optional LOESS
-overlay. The original template covers nine figures — unstratified and
-sex-stratified variants of three echo outcomes (AV mean gradient, AV area, DVI)
-plus an ordinal MV regurgitation grade plot.
-
-`plot()` returns a bare ggplot. Compose with `scale_colour_manual()`,
-`scale_x_continuous()`, `scale_y_continuous()`, `coord_cartesian()`, `labs()`,
-and `theme_hv_manuscript()`.
+grouping variable. `plot()` accepts `add_smooth = TRUE` for an optional
+LOESS overlay and returns a bare ggplot. The original template covers nine
+figures — unstratified and sex-stratified variants of three echo outcomes
+(AV mean gradient, AV area, DVI) plus an ordinal MV regurgitation grade
+plot.
 
 ## Sample data
 
@@ -2085,9 +2084,9 @@ ggsave(here::here("graphs", "mp.amngrd_profile.pdf"),
 nonparametric temporal trend model — the R equivalent of the SAS
 `tp.np.*.avrg_curv.*` and `tp.np.*.u.trend.*` template family.
 
-The constructor accepts the SAS `mean_curv` / `boots_ci` datasets exported to
-CSV and read in with `read.csv()`. `plot()` returns a bare ggplot for
-composition with `scale_colour_*`, `labs()`, and `theme_hv_manuscript()`.
+Pass the SAS `mean_curv` and `boots_ci` datasets (read in with
+`read.csv()`) and call `plot()` for a bare ggplot you can dress with
+colour, labels, and a theme the usual way.
 
 ## Sample data
 
@@ -2214,8 +2213,9 @@ save_ppt(p_np,
 cumulative proportional-odds model — the R equivalent of `tp.np.*.ordinal.*`
 SAS templates (e.g. TR grade prevalence, AR severity).
 
-The SAS `predict` dataset stores one column per grade (`p0`, `p1`, `p2`, `p3`).
-Before calling this function, reshape it from wide to long format:
+The SAS `predict` dataset stores one column per grade (`p0`, `p1`, `p2`,
+`p3`). You'll need to reshape it to long format before passing it to the
+constructor:
 
 ```r
 library(tidyr)
@@ -2343,9 +2343,9 @@ measurements at each follow-up window, paired with a numeric summary table
 below. Call `plot(lc)` for the bar chart and `plot(lc, type = "table")` for the
 table panel. Compose the two panels with `patchwork`.
 
-Input is **pre-aggregated long-format data** — one row per (time window, series)
-combination. Use `sample_longitudinal_counts_data()` to derive this from
-patient-level data, or build it yourself from your registry data.
+Input must be **pre-aggregated long-format data** (one row per time-window
+× series combination). Use `sample_longitudinal_counts_data()` to derive
+this from patient-level data, or build it yourself from your registry data.
 
 ## Sample data
 
@@ -2433,7 +2433,8 @@ save_ppt(p_lc_bar,
 
 `hv_upset()` builds an UpSet diagram via `ggupset::scale_x_upset()` to
 visualise surgical procedure co-occurrences or any set membership data.
-Unlike Venn diagrams, UpSet plots scale to many sets cleanly.
+Where a Venn diagram breaks down past three or four sets, UpSet scales
+cleanly to seven or more.
 
 `plot.hv_upset()` returns a **ggplot** when `set_size = FALSE`, or a
 **patchwork composite** of an intersection-bar plot + a set-size sidebar
@@ -2528,8 +2529,8 @@ ggplot2::ggsave(here::here("graphs", "procedure_cooccurrence.pdf"),
 
 `make_footnote()` writes a small annotation to the **bottom-right corner** of
 the current graphics device using grid. Call it *after* printing a plot to mark
-the figure as a work-in-progress during analysis. For publication-ready output,
-simply omit the call — the plot itself is unchanged.
+the figure as a work-in-progress during analysis. When you're ready for final
+output, omit the call — the plot object itself is untouched.
 
 ```
 # During analysis                   # For publication

--- a/vignettes/plot-functions.qmd
+++ b/vignettes/plot-functions.qmd
@@ -763,15 +763,16 @@ and `tp.dp.EDA_barplots_scatterplots_varnames.R`, replacing base-R graphics
 with composable `ggplot2` objects.
 
 Three helpers support the workflow: `eda_classify_var()` detects whether a
-column is continuous, numeric-categorical, or character-categorical (matching
-the `UniqueLimit` logic from the template); `eda_select_vars()` subsets and
+column is continuous (`"Cont"`), numeric-categorical (`"Cat_Num"`), or
+character-categorical (`"Cat_Char"`) (matching the `UniqueLimit` logic from the
+template); `eda_select_vars()` subsets and
 reorders columns by name or space-separated string, replacing the
 `Order_Variables()` / `Mod_Data <- dta[, Order_Var]` pattern from the varnames
 template; and `sample_eda_data()` generates a reproducible mixed-type dataset
 for demonstration.
 
 `plot()` on an `hv_eda` object returns a bare `ggplot`. Add colour scales,
-axis labels, annotations, and a theme the usual way.
+axis labels, annotations, and `theme_hv_manuscript()`.
 
 ## Sample data
 
@@ -1603,7 +1604,7 @@ ggsave("../graphs/hazard_survival.pdf", p_hp, width = 11.5, height = 8)
 
 The constructor accepts patient-level data and computes annual summaries
 (mean or median) internally. `plot()` returns a bare ggplot; add scales,
-labels, annotations, and a theme the usual way.
+labels, annotations, and `theme_hv_manuscript()`.
 
 ## Sample data
 
@@ -1905,7 +1906,7 @@ ggsave(here::here("graphs", "rp.trends.pdf"), p_tr, width = 11.5, height = 8)
 `hv_spaghetti()` ports the pattern from `tp.dp.spaghetti.echo.R`: one
 trajectory line per subject over time, with optional stratification by a
 grouping variable. `plot()` accepts `add_smooth = TRUE` for an optional
-LOESS overlay and returns a bare ggplot. The original template covers nine
+LOESS overlay and returns a bare ggplot you can dress with `theme_hv_manuscript()`. The original template covers nine
 figures — unstratified and sex-stratified variants of three echo outcomes
 (AV mean gradient, AV area, DVI) plus an ordinal MV regurgitation grade
 plot.
@@ -2086,7 +2087,7 @@ nonparametric temporal trend model — the R equivalent of the SAS
 
 Pass the SAS `mean_curv` and `boots_ci` datasets (read in with
 `read.csv()`) and call `plot()` for a bare ggplot you can dress with
-colour, labels, and a theme the usual way.
+colour, labels, and `theme_hv_manuscript()`.
 
 ## Sample data
 

--- a/vignettes/sas-migration-guide.html
+++ b/vignettes/sas-migration-guide.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="John Ehrlinger ehrlinj@ccf.org">
-<meta name="dcterms.date" content="2026-05-22">
+<meta name="dcterms.date" content="2026-05-26">
 
 <title>SAS Template Migration Guide: Finding Your Plot in R</title>
 <style>
@@ -183,7 +183,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 22, 2026</p>
+      <p class="date">May 26, 2026</p>
     </div>
   </div>
   
@@ -208,7 +208,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="dv">0</span><span class="sc">:</span><span class="dv">12</span>) <span class="sc">+</span></span>
 <span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Prevalence (%)"</span>) <span class="sc">+</span></span>
 <span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
-<p><strong><code>theme_hv_manuscript()</code> replaces SAS <code>device=</code> / style options.</strong> Use <code>"dark_ppt"</code> / <code>"ppt"</code> for PowerPoint slides, <code>"light_ppt"</code> for light-background slides, <code>"manuscript"</code> for journal figures, and <code>"poster"</code> for conference posters.</p>
+<p><strong>The <code>theme_hv_*()</code> functions replace SAS <code>device=</code> / style options.</strong> Use <code>theme_hv_ppt_dark()</code> for PowerPoint slides on dark backgrounds, <code>theme_hv_ppt_light()</code> for light/transparent slides, <code>theme_hv_manuscript()</code> for journal figures, and <code>theme_hv_poster()</code> for conference posters.</p>
 <p><strong>Functions return a ggplot object; they do not display it.</strong> Call the plot object at the top level (or use <code>print()</code>) to render it, or save with <code>ggsave()</code> / <code>save_ppt()</code>.</p>
 <p><strong>Pre-fitted models, not raw data.</strong> Most functions accept the <em>output</em> of a statistical model (curve datasets, probability estimates) rather than individual patient records — mirroring the SAS workflow where <code>%decompos()</code> or <code>%kaplan</code> computes estimates and a separate template step produces the figure.</p>
 <hr>

--- a/vignettes/sas-migration-guide.html
+++ b/vignettes/sas-migration-guide.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="John Ehrlinger ehrlinj@ccf.org">
-<meta name="dcterms.date" content="2026-04-20">
+<meta name="dcterms.date" content="2026-05-22">
 
 <title>SAS Template Migration Guide: Finding Your Plot in R</title>
 <style>
@@ -183,7 +183,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">April 20, 2026</p>
+      <p class="date">May 22, 2026</p>
     </div>
   </div>
   
@@ -198,7 +198,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="overview" class="level1">
 <h1>Overview</h1>
 <p>This guide maps every SAS template in the HVTI statistics group template library to its R equivalent in the <strong>hvtiPlotR</strong> package. If you know the SAS template name (e.g., <code>tp.np.afib.ivwristm.avrg_curv.binary.sas</code>), look it up in the table below and jump to the corresponding section for a working R example.</p>
-<p>The guide is organized by template family (the two-letter prefix after <code>tp.</code>). New ports are added to this document as they become available.</p>
+<p>The guide is organized by template family (the two-letter prefix after <code>tp.</code>). We add new ports as they become available.</p>
 <section id="key-concepts-for-sas-users" class="level2">
 <h2 class="anchored" data-anchor-id="key-concepts-for-sas-users">Key concepts for SAS users</h2>
 <p><strong>ggplot2 builds plots in layers.</strong> Instead of one macro call with many <code>color=</code>, <code>xaxis=</code>, and <code>footnote=</code> options, you chain <code>+</code> operations:</p>
@@ -207,8 +207,8 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="st">"black"</span>, <span class="st">"gray40"</span>)) <span class="sc">+</span></span>
 <span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="dv">0</span><span class="sc">:</span><span class="dv">12</span>) <span class="sc">+</span></span>
 <span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Prevalence (%)"</span>) <span class="sc">+</span></span>
-<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
-<p><strong><code>hv_theme()</code> replaces SAS <code>device=</code> / style options.</strong> Use <code>"dark_ppt"</code> / <code>"ppt"</code> for PowerPoint slides, <code>"light_ppt"</code> for light-background slides, <code>"manuscript"</code> for journal figures, and <code>"poster"</code> for conference posters.</p>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<p><strong><code>theme_hv_manuscript()</code> replaces SAS <code>device=</code> / style options.</strong> Use <code>"dark_ppt"</code> / <code>"ppt"</code> for PowerPoint slides, <code>"light_ppt"</code> for light-background slides, <code>"manuscript"</code> for journal figures, and <code>"poster"</code> for conference posters.</p>
 <p><strong>Functions return a ggplot object; they do not display it.</strong> Call the plot object at the top level (or use <code>print()</code>) to render it, or save with <code>ggsave()</code> / <code>save_ppt()</code>.</p>
 <p><strong>Pre-fitted models, not raw data.</strong> Most functions accept the <em>output</em> of a statistical model (curve datasets, probability estimates) rather than individual patient records — mirroring the SAS workflow where <code>%decompos()</code> or <code>%kaplan</code> computes estimates and a separate template step produces the figure.</p>
 <hr>
@@ -561,7 +561,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>    <span class="at">y     =</span> <span class="st">"Prevalence (%)"</span>,</span>
 <span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Atrial Fibrillation Prevalence"</span></span>
 <span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -588,7 +588,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a>    <span class="at">y     =</span> <span class="st">"Prevalence (%)"</span>,</span>
 <span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Atrial Fibrillation — 68% CI"</span></span>
 <span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb4-17"><a href="#cb4-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -616,7 +616,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>    <span class="at">y     =</span> <span class="st">"Prevalence (%)"</span>,</span>
 <span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Atrial Fibrillation with Binned Observations"</span></span>
 <span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -660,7 +660,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb6-27"><a href="#cb6-27" aria-hidden="true" tabindex="-1"></a>    <span class="at">label =</span> <span class="st">"68% CI band"</span>,</span>
 <span id="cb6-28"><a href="#cb6-28" aria-hidden="true" tabindex="-1"></a>    <span class="at">hjust =</span> <span class="dv">1</span>, <span class="at">size =</span> <span class="dv">3</span></span>
 <span id="cb6-29"><a href="#cb6-29" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb6-30"><a href="#cb6-30" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb6-30"><a href="#cb6-30" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -713,7 +713,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb7-36"><a href="#cb7-36" aria-hidden="true" tabindex="-1"></a>    <span class="at">fill   =</span> <span class="st">"Valve type"</span>,</span>
 <span id="cb7-37"><a href="#cb7-37" aria-hidden="true" tabindex="-1"></a>    <span class="at">title  =</span> <span class="st">"Atrial Fibrillation by Valve Type"</span></span>
 <span id="cb7-38"><a href="#cb7-38" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb7-39"><a href="#cb7-39" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb7-39"><a href="#cb7-39" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -759,7 +759,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb8-29"><a href="#cb8-29" aria-hidden="true" tabindex="-1"></a>    <span class="at">colour =</span> <span class="cn">NULL</span>,</span>
 <span id="cb8-30"><a href="#cb8-30" aria-hidden="true" tabindex="-1"></a>    <span class="at">title  =</span> <span class="st">"AF — Early and Late Phase Decomposition"</span></span>
 <span id="cb8-31"><a href="#cb8-31" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb8-32"><a href="#cb8-32" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb8-32"><a href="#cb8-32" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -808,7 +808,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span id="cb9-32"><a href="#cb9-32" aria-hidden="true" tabindex="-1"></a>    <span class="at">y     =</span> <span class="st">"Estimated Probability"</span>,</span>
 <span id="cb9-33"><a href="#cb9-33" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Outcome Probability vs. BMI at Operation"</span></span>
 <span id="cb9-34"><a href="#cb9-34" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb9-35"><a href="#cb9-35" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb9-35"><a href="#cb9-35" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -821,7 +821,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <section id="np-ordinal" class="level2">
 <h2 class="anchored" data-anchor-id="np-ordinal">Ordinal outcomes</h2>
 <p><strong>Port:</strong> <code>tp.np.tr.ivecho.average_curv.ordinal.sas</code></p>
-<p>Ordinal templates (TR grade, AR grade) use <code>hv_ordinal()</code>. The critical migration step is reshaping the SAS wide-format <code>predict</code> dataset (one column per grade) to long format.</p>
+<p>Ordinal templates (TR grade, AR grade) use <code>hv_ordinal()</code>. The main migration step is reshaping the SAS wide-format <code>predict</code> dataset (one column per grade) to long format.</p>
 <p><strong>SAS reshape (do this before reading into R):</strong></p>
 <pre class="sas"><code>/* SAS wide format: p0, p1, p2, p3 */
 data predict_wide;
@@ -873,7 +873,7 @@ run;</code></pre>
 <span id="cb12-35"><a href="#cb12-35" aria-hidden="true" tabindex="-1"></a>    <span class="at">colour =</span> <span class="st">"TR Grade"</span>,</span>
 <span id="cb12-36"><a href="#cb12-36" aria-hidden="true" tabindex="-1"></a>    <span class="at">title  =</span> <span class="st">"Tricuspid Regurgitation Grade"</span></span>
 <span id="cb12-37"><a href="#cb12-37" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb12-38"><a href="#cb12-38" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb12-38"><a href="#cb12-38" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -906,7 +906,7 @@ run;</code></pre>
 <span id="cb13-18"><a href="#cb13-18" aria-hidden="true" tabindex="-1"></a>    <span class="at">colour =</span> <span class="st">"AR Grade"</span>,</span>
 <span id="cb13-19"><a href="#cb13-19" aria-hidden="true" tabindex="-1"></a>    <span class="at">title  =</span> <span class="st">"AR Grade — Before vs. After Repair"</span></span>
 <span id="cb13-20"><a href="#cb13-20" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb13-21"><a href="#cb13-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -942,7 +942,7 @@ run;</code></pre>
 <span id="cb14-19"><a href="#cb14-19" aria-hidden="true" tabindex="-1"></a>    <span class="at">y     =</span> <span class="st">"Probability"</span>,</span>
 <span id="cb14-20"><a href="#cb14-20" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Probability of TR Grade 2"</span></span>
 <span id="cb14-21"><a href="#cb14-21" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb14-22"><a href="#cb14-22" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb14-22"><a href="#cb14-22" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -984,7 +984,7 @@ run;</code></pre>
 <span id="cb15-25"><a href="#cb15-25" aria-hidden="true" tabindex="-1"></a>    <span class="at">colour =</span> <span class="st">"TR Grade"</span>,</span>
 <span id="cb15-26"><a href="#cb15-26" aria-hidden="true" tabindex="-1"></a>    <span class="at">title  =</span> <span class="st">"TR Grade — Early and Late Phase"</span></span>
 <span id="cb15-27"><a href="#cb15-27" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb15-28"><a href="#cb15-28" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb15-28"><a href="#cb15-28" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output-display">
 <div>
 <figure class="figure">
@@ -1001,7 +1001,7 @@ run;</code></pre>
 <h1>Survival analysis (<code>tp.ac.dead.*</code>, <code>tp.cp.dead.*</code>)</h1>
 <p><strong>Ports:</strong> <code>tp.ac.dead.sas</code>, <code>tp.cp.dead.sas</code></p>
 <p><strong>R equivalent:</strong> <code>hv_survival()</code></p>
-<p><code>hv_survival()</code> wraps <code>survfit()</code> from the <strong>survival</strong> package and returns an S3 object. Call <code>plot(km, type = ...)</code> to render one of the five plot types matching the SAS <code>%kaplan</code> / <code>%nelsont</code> macro output flags (<code>PLOTS</code>, <code>PLOTC</code>, <code>PLOTH</code>, <code>PLOTL</code>). Tidy data frames are accessible via <code>km$tables</code>.</p>
+<p><code>hv_survival()</code> wraps <code>survfit()</code> from the <strong>survival</strong> package and returns an S3 object. Call <code>plot(km, type = ...)</code> to render one of the five plot types matching the SAS <code>%kaplan</code> / <code>%nelsont</code> macro output flags (<code>PLOTS</code>, <code>PLOTC</code>, <code>PLOTH</code>, <code>PLOTL</code>). Tidy data frames live in <code>km$tables</code>.</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb16"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>dta <span class="ot">&lt;-</span> <span class="fu">sample_survival_data</span>(<span class="at">n =</span> <span class="dv">500</span>, <span class="at">seed =</span> <span class="dv">42</span>)</span>
 <span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>km  <span class="ot">&lt;-</span> <span class="fu">hv_survival</span>(dta)</span>
 <span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a></span>
@@ -1018,27 +1018,27 @@ run;</code></pre>
 <span id="cb16-14"><a href="#cb16-14" aria-hidden="true" tabindex="-1"></a>    <span class="at">y     =</span> <span class="st">"Survival (%)"</span>,</span>
 <span id="cb16-15"><a href="#cb16-15" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Freedom from Death"</span></span>
 <span id="cb16-16"><a href="#cb16-16" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb16-17"><a href="#cb16-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb16-18"><a href="#cb16-18" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb16-19"><a href="#cb16-19" aria-hidden="true" tabindex="-1"></a><span class="co"># Cumulative hazard (PLOTC)</span></span>
 <span id="cb16-20"><a href="#cb16-20" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km, <span class="at">type =</span> <span class="st">"cumhaz"</span>) <span class="sc">+</span></span>
 <span id="cb16-21"><a href="#cb16-21" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"Cumulative Hazard"</span>) <span class="sc">+</span></span>
-<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb16-22"><a href="#cb16-22" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb16-23"><a href="#cb16-23" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb16-24"><a href="#cb16-24" aria-hidden="true" tabindex="-1"></a><span class="co"># Hazard rate (PLOTH)</span></span>
 <span id="cb16-25"><a href="#cb16-25" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km, <span class="at">type =</span> <span class="st">"hazard"</span>) <span class="sc">+</span></span>
 <span id="cb16-26"><a href="#cb16-26" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"Instantaneous Hazard"</span>) <span class="sc">+</span></span>
-<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb16-27"><a href="#cb16-27" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb16-28"><a href="#cb16-28" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb16-29"><a href="#cb16-29" aria-hidden="true" tabindex="-1"></a><span class="co"># Log-log survival (PH check)</span></span>
 <span id="cb16-30"><a href="#cb16-30" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km, <span class="at">type =</span> <span class="st">"loglog"</span>) <span class="sc">+</span></span>
 <span id="cb16-31"><a href="#cb16-31" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"log(Years)"</span>, <span class="at">y =</span> <span class="st">"log(-log S(t))"</span>) <span class="sc">+</span></span>
-<span id="cb16-32"><a href="#cb16-32" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb16-32"><a href="#cb16-32" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb16-33"><a href="#cb16-33" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb16-34"><a href="#cb16-34" aria-hidden="true" tabindex="-1"></a><span class="co"># Integrated survivorship (PLOTL)</span></span>
 <span id="cb16-35"><a href="#cb16-35" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(km, <span class="at">type =</span> <span class="st">"life"</span>) <span class="sc">+</span></span>
 <span id="cb16-36"><a href="#cb16-36" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"Restricted Mean Survival (years)"</span>) <span class="sc">+</span></span>
-<span id="cb16-37"><a href="#cb16-37" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb16-37"><a href="#cb16-37" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb16-38"><a href="#cb16-38" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb16-39"><a href="#cb16-39" aria-hidden="true" tabindex="-1"></a><span class="co"># Access the KM data, risk table, and report table</span></span>
 <span id="cb16-40"><a href="#cb16-40" aria-hidden="true" tabindex="-1"></a>km<span class="sc">$</span>data              <span class="co"># tidy KM data frame</span></span>
@@ -1109,14 +1109,14 @@ run;</code></pre>
 <span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(gf) <span class="sc">+</span></span>
 <span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">title =</span> <span class="st">"Goodness of Follow-Up"</span>) <span class="sc">+</span></span>
-<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 <section id="lp-covbal" class="level1">
 <h1>Covariate balance (<code>tp.lp.propen.cov_balance.R</code>)</h1>
 <p><strong>Port:</strong> <code>tp.lp.propen.cov_balance.R</code></p>
 <p><strong>R equivalent:</strong> <code>hv_balance()</code></p>
-<p>The SAS export arrives wide (one column per time-point). Reshape to long format before calling <code>hv_balance()</code>. Pass <code>var_levels</code> to control the bottom-to-top display order of covariates (matches <code>ylabel</code> in the original script).</p>
+<p>The SAS export arrives wide (one column per time-point). Reshape to long format before you call <code>hv_balance()</code>. Pass <code>var_levels</code> to control the bottom-to-top display order of covariates — this matches <code>ylabel</code> in the original script.</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb18"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Reshape wide → long (mirrors the original script)</span></span>
 <span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>ylabel <span class="ot">&lt;-</span> <span class="fu">c</span>(</span>
 <span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="st">"Cardiac Output"</span>, <span class="st">"BAV"</span>, <span class="st">"Cardiac Index"</span>, <span class="st">"NYHA -Functional Class"</span>,</span>
@@ -1159,7 +1159,7 @@ run;</code></pre>
 <span id="cb18-40"><a href="#cb18-40" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>, <span class="at">x =</span> <span class="sc">-</span><span class="dv">30</span>, <span class="at">y =</span> <span class="dv">0</span>,      <span class="at">label =</span> <span class="st">"More likely TF-TAVR"</span>, <span class="at">size =</span> <span class="fl">4.5</span>) <span class="sc">+</span></span>
 <span id="cb18-41"><a href="#cb18-41" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>, <span class="at">x =</span>  <span class="dv">22</span>, <span class="at">y =</span> n_vars, <span class="at">label =</span> <span class="st">"More likely SAVR"</span>,    <span class="at">size =</span> <span class="fl">4.5</span>) <span class="sc">+</span></span>
 <span id="cb18-42"><a href="#cb18-42" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme</span>(<span class="at">legend.position =</span> <span class="fu">c</span>(<span class="fl">0.20</span>, <span class="fl">0.935</span>)) <span class="sc">+</span></span>
-<span id="cb18-43"><a href="#cb18-43" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb18-43"><a href="#cb18-43" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb18-44"><a href="#cb18-44" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb18-45"><a href="#cb18-45" aria-hidden="true" tabindex="-1"></a><span class="fu">ggsave</span>(here<span class="sc">::</span><span class="fu">here</span>(<span class="st">"graphs"</span>, <span class="st">"lp_cov-balance-SAVR_TF-TAVR.pdf"</span>),</span>
 <span id="cb18-46"><a href="#cb18-46" aria-hidden="true" tabindex="-1"></a>       <span class="at">plot =</span> stdifPlot, <span class="at">height =</span> <span class="dv">7</span>, <span class="at">width =</span> <span class="dv">8</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
@@ -1175,7 +1175,7 @@ run;</code></pre>
 <span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(al) <span class="sc">+</span></span>
 <span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_brewer</span>(<span class="at">palette =</span> <span class="st">"Set2"</span>) <span class="sc">+</span></span>
 <span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">title =</span> <span class="st">"Patient Flow Between States"</span>) <span class="sc">+</span></span>
-<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 <section id="dp-cluster-sankey" class="level1">
@@ -1223,7 +1223,7 @@ run;</code></pre>
 <span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(sk) <span class="sc">+</span></span>
 <span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">title =</span> <span class="st">"Cluster Stability: K = 2 to 9"</span>) <span class="sc">+</span></span>
-<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <p>To reproduce the original analysis with patient-level cluster assignments:</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb22"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Build a data frame with one row per patient, columns C2..C9 (factor)</span></span>
 <span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a>grp_dta <span class="ot">&lt;-</span> <span class="fu">data.frame</span>(</span>
@@ -1241,7 +1241,7 @@ run;</code></pre>
 <span id="cb22-14"><a href="#cb22-14" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb22-15"><a href="#cb22-15" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(sk_grp) <span class="sc">+</span></span>
 <span id="cb22-16"><a href="#cb22-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="cn">NULL</span>) <span class="sc">+</span></span>
-<span id="cb22-17"><a href="#cb22-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb22-17"><a href="#cb22-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 </section>
@@ -1271,7 +1271,7 @@ run;</code></pre>
 <span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">80</span>, <span class="dv">20</span>)) <span class="sc">+</span></span>
 <span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">5</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">80</span>)) <span class="sc">+</span></span>
 <span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"AV Mean Gradient (mmHg)"</span>) <span class="sc">+</span></span>
-<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="unstratified-zoomed-y-axis-plot_3" class="level2">
 <h2 class="anchored" data-anchor-id="unstratified-zoomed-y-axis-plot_3">Unstratified — zoomed y-axis (plot_3)</h2>
@@ -1280,7 +1280,7 @@ run;</code></pre>
 <span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">30</span>, <span class="dv">10</span>)) <span class="sc">+</span></span>
 <span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">5</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">30</span>)) <span class="sc">+</span></span>
 <span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"AV Mean Gradient (mmHg)"</span>) <span class="sc">+</span></span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="stratified-by-sex-plot_2-plot_4" class="level2">
 <h2 class="anchored" data-anchor-id="stratified-by-sex-plot_2-plot_4">Stratified by sex (plot_2 / plot_4)</h2>
@@ -1294,7 +1294,7 @@ run;</code></pre>
 <span id="cb27-7"><a href="#cb27-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">80</span>, <span class="dv">20</span>)) <span class="sc">+</span></span>
 <span id="cb27-8"><a href="#cb27-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">5</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">80</span>)) <span class="sc">+</span></span>
 <span id="cb27-9"><a href="#cb27-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"AV Mean Gradient (mmHg)"</span>) <span class="sc">+</span></span>
-<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb27-10"><a href="#cb27-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="av-area-y-scale-plot_5-plot_6" class="level2">
 <h2 class="anchored" data-anchor-id="av-area-y-scale-plot_5-plot_6">AV area y-scale (plot_5 / plot_6)</h2>
@@ -1307,7 +1307,7 @@ run;</code></pre>
 <span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">5</span>, <span class="dv">1</span>)) <span class="sc">+</span></span>
 <span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">5</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">5</span>)) <span class="sc">+</span></span>
 <span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"AV Area (EOA) (cm\u00b2)"</span>) <span class="sc">+</span></span>
-<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="dvi-y-scale-plot_7-plot_8" class="level2">
 <h2 class="anchored" data-anchor-id="dvi-y-scale-plot_7-plot_8">DVI y-scale (plot_7 / plot_8)</h2>
@@ -1320,7 +1320,7 @@ run;</code></pre>
 <span id="cb29-7"><a href="#cb29-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="fl">1.25</span>, <span class="fl">0.25</span>)) <span class="sc">+</span></span>
 <span id="cb29-8"><a href="#cb29-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">5</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="fl">1.25</span>)) <span class="sc">+</span></span>
 <span id="cb29-9"><a href="#cb29-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"DVI"</span>) <span class="sc">+</span></span>
-<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb29-10"><a href="#cb29-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="ordinal-y-axis-mv-regurgitation-grade-plot_9" class="level2">
 <h2 class="anchored" data-anchor-id="ordinal-y-axis-mv-regurgitation-grade-plot_9">Ordinal y-axis — MV regurgitation grade (plot_9)</h2>
@@ -1338,7 +1338,7 @@ run;</code></pre>
 <span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">6</span>, <span class="dv">1</span>)) <span class="sc">+</span></span>
 <span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">6</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">3</span>)) <span class="sc">+</span></span>
 <span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Procedure"</span>, <span class="at">y =</span> <span class="st">"MV Regurgitation Grade"</span>) <span class="sc">+</span></span>
-<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 </section>
@@ -1356,14 +1356,14 @@ run;</code></pre>
 <span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">1968</span>, <span class="dv">2000</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">1968</span>, <span class="dv">2000</span>, <span class="dv">4</span>)) <span class="sc">+</span></span>
 <span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">10</span>),      <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">10</span>, <span class="dv">2</span>)) <span class="sc">+</span></span>
 <span id="cb31-8"><a href="#cb31-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Year"</span>, <span class="at">y =</span> <span class="st">"Cases/year"</span>) <span class="sc">+</span></span>
-<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span>
+<span id="cb31-9"><a href="#cb31-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span>
 <span id="cb31-10"><a href="#cb31-10" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb31-11"><a href="#cb31-11" aria-hidden="true" tabindex="-1"></a><span class="co"># Age: axisy order=(30 to 70 by 10)</span></span>
 <span id="cb31-12"><a href="#cb31-12" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(tr_one) <span class="sc">+</span></span>
 <span id="cb31-13"><a href="#cb31-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_x_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">1968</span>, <span class="dv">2000</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">1968</span>, <span class="dv">2000</span>, <span class="dv">4</span>)) <span class="sc">+</span></span>
 <span id="cb31-14"><a href="#cb31-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">30</span>, <span class="dv">70</span>),     <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">30</span>, <span class="dv">70</span>, <span class="dv">10</span>)) <span class="sc">+</span></span>
 <span id="cb31-15"><a href="#cb31-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Year"</span>, <span class="at">y =</span> <span class="st">"Age (years)"</span>) <span class="sc">+</span></span>
-<span id="cb31-16"><a href="#cb31-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb31-16"><a href="#cb31-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="tp.lp.trends.sas-binary-outcomes-19702000-by-10-y-0100-by-10" class="level2">
 <h2 class="anchored" data-anchor-id="tp.lp.trends.sas-binary-outcomes-19702000-by-10-y-0100-by-10">tp.lp.trends.sas — binary % outcomes (1970–2000 by 10, y 0–100 by 10)</h2>
@@ -1384,7 +1384,7 @@ run;</code></pre>
 <span id="cb32-14"><a href="#cb32-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>),     <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">10</span>)) <span class="sc">+</span></span>
 <span id="cb32-15"><a href="#cb32-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">1970</span>, <span class="dv">2000</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
 <span id="cb32-16"><a href="#cb32-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Year"</span>, <span class="at">y =</span> <span class="st">"Percent (%)"</span>) <span class="sc">+</span></span>
-<span id="cb32-17"><a href="#cb32-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb32-17"><a href="#cb32-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="tp.lp.trends.age.sas-age-on-x-axis-2585-by-10-y-0100-by-20" class="level2">
 <h2 class="anchored" data-anchor-id="tp.lp.trends.age.sas-age-on-x-axis-2585-by-10-y-0100-by-20">tp.lp.trends.age.sas — age on x-axis (25–85 by 10, y 0–100 by 20)</h2>
@@ -1401,7 +1401,7 @@ run;</code></pre>
 <span id="cb33-11"><a href="#cb33-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">20</span>)) <span class="sc">+</span></span>
 <span id="cb33-12"><a href="#cb33-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">25</span>, <span class="dv">85</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
 <span id="cb33-13"><a href="#cb33-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Age (years)"</span>, <span class="at">y =</span> <span class="st">"Percent (%)"</span>) <span class="sc">+</span></span>
-<span id="cb33-14"><a href="#cb33-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb33-14"><a href="#cb33-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="tp.lp.trends.polytomous.sas-repair-types-19901999-by-1-y-0100-by-10" class="level2">
 <h2 class="anchored" data-anchor-id="tp.lp.trends.polytomous.sas-repair-types-19901999-by-1-y-0100-by-10">tp.lp.trends.polytomous.sas — repair types (1990–1999 by 1, y 0–100 by 10)</h2>
@@ -1422,7 +1422,7 @@ run;</code></pre>
 <span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>),     <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">10</span>)) <span class="sc">+</span></span>
 <span id="cb34-16"><a href="#cb34-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">1990</span>, <span class="dv">1999</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>)) <span class="sc">+</span></span>
 <span id="cb34-17"><a href="#cb34-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Year"</span>, <span class="at">y =</span> <span class="st">"Percent (%)"</span>) <span class="sc">+</span></span>
-<span id="cb34-18"><a href="#cb34-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb34-18"><a href="#cb34-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="tp.dp.trends.r-lv-mass-index-19952015-by-5-y-0200-by-50" class="level2">
 <h2 class="anchored" data-anchor-id="tp.dp.trends.r-lv-mass-index-19952015-by-5-y-0200-by-50">tp.dp.trends.R — LV mass index (1995–2015 by 5, y 0–200 by 50)</h2>
@@ -1435,7 +1435,7 @@ run;</code></pre>
 <span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">200</span>),     <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">200</span>, <span class="dv">50</span>)) <span class="sc">+</span></span>
 <span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">coord_cartesian</span>(<span class="at">xlim =</span> <span class="fu">c</span>(<span class="dv">1995</span>, <span class="dv">2015</span>), <span class="at">ylim =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">200</span>)) <span class="sc">+</span></span>
 <span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"LV Mass Index"</span>) <span class="sc">+</span></span>
-<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="tp.dp.trends.r-hospital-los-with-annotation-19852015-by-5-y-020-by-5" class="level2">
 <h2 class="anchored" data-anchor-id="tp.dp.trends.r-hospital-los-with-annotation-19852015-by-5-y-020-by-5">tp.dp.trends.R — hospital LOS with annotation (1985–2015 by 5, y 0–20 by 5)</h2>
@@ -1450,7 +1450,7 @@ run;</code></pre>
 <span id="cb36-9"><a href="#cb36-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>, <span class="at">x =</span> <span class="dv">1995</span>, <span class="at">y =</span> <span class="dv">18</span>,</span>
 <span id="cb36-10"><a href="#cb36-10" aria-hidden="true" tabindex="-1"></a>           <span class="at">label =</span> <span class="st">"Trend: Hospital Length of Stay"</span>, <span class="at">size =</span> <span class="fl">4.5</span>) <span class="sc">+</span></span>
 <span id="cb36-11"><a href="#cb36-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"Hospital LOS (Days)"</span>) <span class="sc">+</span></span>
-<span id="cb36-12"><a href="#cb36-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb36-12"><a href="#cb36-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 </section>
@@ -1468,13 +1468,13 @@ run;</code></pre>
 <span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a>    <span class="at">y     =</span> <span class="st">"Patients with measurement"</span>,</span>
 <span id="cb37-9"><a href="#cb37-9" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Follow-Up Echocardiogram Availability"</span></span>
 <span id="cb37-10"><a href="#cb37-10" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb37-11"><a href="#cb37-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb37-11"><a href="#cb37-11" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 <section id="dp-mirror" class="level1">
 <h1>Mirror histogram (propensity score)</h1>
 <p><strong>R equivalents:</strong> <code>tp.lp.mirror-histogram_SAVR-TF-TAVR.R</code> (binary-match), <code>tp.lp.mirror_histo_before_after_wt.R</code> (weighted IPTW)</p>
-<p>Both scripts are superseded by <code>hv_mirror_hist()</code>. Call <code>plot(mh)</code> to render the histogram. Diagnostics are accessible via <code>mh$tables$diagnostics</code>; working data via <code>mh$tables$working</code>. Compose scales, annotations, and theme with the usual <code>+</code> operator.</p>
+<p><code>hv_mirror_hist()</code> replaces both scripts. Call <code>plot(mh)</code> to render. Diagnostics are in <code>mh$tables$diagnostics</code>, working data in <code>mh$tables$working</code>; layer scales, annotations, and a theme the usual way.</p>
 <section id="dp-mirror-binary" class="level2">
 <h2 class="anchored" data-anchor-id="dp-mirror-binary">Binary-match mode (<code>tp.lp.mirror-histogram_SAVR-TF-TAVR.R</code>)</h2>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb38"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a>dta <span class="ot">&lt;-</span> <span class="fu">sample_mirror_histogram_data</span>(<span class="at">n =</span> <span class="dv">400</span>, <span class="at">separation =</span> <span class="fl">1.5</span>)</span>
@@ -1492,7 +1492,7 @@ run;</code></pre>
 <span id="cb38-13"><a href="#cb38-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>, <span class="at">x =</span> <span class="dv">20</span>, <span class="at">y =</span>  <span class="dv">100</span>, <span class="at">label =</span> <span class="st">"SAVR"</span>,    <span class="at">size =</span> <span class="dv">7</span>) <span class="sc">+</span></span>
 <span id="cb38-14"><a href="#cb38-14" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>, <span class="at">x =</span> <span class="dv">20</span>, <span class="at">y =</span> <span class="sc">-</span><span class="dv">100</span>, <span class="at">label =</span> <span class="st">"TF-TAVR"</span>, <span class="at">size =</span> <span class="dv">7</span>) <span class="sc">+</span></span>
 <span id="cb38-15"><a href="#cb38-15" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Propensity Score (%)"</span>, <span class="at">y =</span> <span class="st">"Number of Patients"</span>) <span class="sc">+</span></span>
-<span id="cb38-16"><a href="#cb38-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb38-16"><a href="#cb38-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="dp-mirror-weighted" class="level2">
 <h2 class="anchored" data-anchor-id="dp-mirror-weighted">Weighted IPTW mode (<code>tp.lp.mirror_histo_before_after_wt.R</code>)</h2>
@@ -1515,7 +1515,7 @@ run;</code></pre>
 <span id="cb39-17"><a href="#cb39-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>, <span class="at">x =</span> <span class="dv">30</span>, <span class="at">y =</span>  <span class="dv">150</span>, <span class="at">label =</span> <span class="st">"Limited"</span>,  <span class="at">color =</span> <span class="st">"blue"</span>, <span class="at">size =</span> <span class="dv">5</span>) <span class="sc">+</span></span>
 <span id="cb39-18"><a href="#cb39-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">annotate</span>(<span class="st">"text"</span>, <span class="at">x =</span> <span class="dv">30</span>, <span class="at">y =</span> <span class="sc">-</span><span class="dv">70</span>,  <span class="at">label =</span> <span class="st">"Extended"</span>, <span class="at">color =</span> <span class="st">"red"</span>,  <span class="at">size =</span> <span class="dv">5</span>) <span class="sc">+</span></span>
 <span id="cb39-19"><a href="#cb39-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Propensity Score (%)"</span>, <span class="at">y =</span> <span class="st">"#"</span>) <span class="sc">+</span></span>
-<span id="cb39-20"><a href="#cb39-20" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb39-20"><a href="#cb39-20" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 </section>
@@ -1533,7 +1533,7 @@ run;</code></pre>
 <span id="cb40-9"><a href="#cb40-9" aria-hidden="true" tabindex="-1"></a>    <span class="at">fill  =</span> <span class="st">"Group"</span>,</span>
 <span id="cb40-10"><a href="#cb40-10" aria-hidden="true" tabindex="-1"></a>    <span class="at">title =</span> <span class="st">"Annual Case Volume by Group"</span></span>
 <span id="cb40-11"><a href="#cb40-11" aria-hidden="true" tabindex="-1"></a>  ) <span class="sc">+</span></span>
-<span id="cb40-12"><a href="#cb40-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb40-12"><a href="#cb40-12" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 <section id="using-themes" class="level1">
@@ -1555,29 +1555,29 @@ run;</code></pre>
 <tbody>
 <tr class="odd">
 <td>Dark PowerPoint slide</td>
-<td><code>hv_theme("dark_ppt")</code></td>
+<td><code>theme_hv_ppt_dark()</code></td>
 <td><code>device=ppt</code></td>
 </tr>
 <tr class="even">
 <td>Light PowerPoint slide</td>
-<td><code>hv_theme("light_ppt")</code></td>
+<td><code>theme_hv_ppt_light()</code></td>
 <td><code>device=ppt</code> with white background</td>
 </tr>
 <tr class="odd">
 <td>Journal manuscript</td>
-<td><code>hv_theme("manuscript")</code></td>
+<td><code>theme_hv_manuscript()</code></td>
 <td><code>device=eps</code> / PDF</td>
 </tr>
 <tr class="even">
 <td>Conference poster</td>
-<td><code>hv_theme("poster")</code></td>
+<td><code>theme_hv_poster()</code></td>
 <td>Large-font poster</td>
 </tr>
 </tbody>
 </table>
 <p>You can pass <code>base_size</code> to any theme to scale all text simultaneously:</p>
-<div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb41"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a>p <span class="sc">+</span> <span class="fu">hv_theme</span>(<span class="st">"manuscript"</span>, <span class="at">base_size =</span> <span class="dv">10</span>)   <span class="co"># smaller text for double-column</span></span>
-<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a>p <span class="sc">+</span> <span class="fu">hv_theme</span>(<span class="st">"poster"</span>,     <span class="at">base_size =</span> <span class="dv">24</span>)   <span class="co"># larger text for A0 poster</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb41"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a>p <span class="sc">+</span> <span class="fu">theme_hv_manuscript</span>(<span class="at">base_size =</span> <span class="dv">10</span>)   <span class="co"># smaller text for double-column</span></span>
+<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a>p <span class="sc">+</span> <span class="fu">theme_hv_poster</span>(<span class="at">base_size =</span> <span class="dv">24</span>)   <span class="co"># larger text for A0 poster</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 <section id="saving-figures" class="level1">
@@ -1593,7 +1593,7 @@ run;</code></pre>
 <span id="cb42-6"><a href="#cb42-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_colour_manual</span>(<span class="at">values =</span> <span class="fu">c</span>(<span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
 <span id="cb42-7"><a href="#cb42-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_fill_manual</span>(<span class="at">values   =</span> <span class="fu">c</span>(<span class="st">"steelblue"</span>), <span class="at">guide =</span> <span class="st">"none"</span>) <span class="sc">+</span></span>
 <span id="cb42-8"><a href="#cb42-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"Prevalence (%)"</span>) <span class="sc">+</span></span>
-<span id="cb42-9"><a href="#cb42-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"dark_ppt"</span>)</span>
+<span id="cb42-9"><a href="#cb42-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_ppt_dark</span>()</span>
 <span id="cb42-10"><a href="#cb42-10" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb42-11"><a href="#cb42-11" aria-hidden="true" tabindex="-1"></a><span class="fu">save_ppt</span>(</span>
 <span id="cb42-12"><a href="#cb42-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">object       =</span> p_ppt,</span>
@@ -1680,7 +1680,7 @@ run;</code></pre>
 <span id="cb44-16"><a href="#cb44-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">10</span>),</span>
 <span id="cb44-17"><a href="#cb44-17" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
 <span id="cb44-18"><a href="#cb44-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Survival (%)"</span>) <span class="sc">+</span></span>
-<span id="cb44-19"><a href="#cb44-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb44-19"><a href="#cb44-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="stratified-by-covariate" class="level2">
 <h2 class="anchored" data-anchor-id="stratified-by-covariate">Stratified by covariate</h2>
@@ -1716,11 +1716,11 @@ run;</code></pre>
 <span id="cb45-29"><a href="#cb45-29" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">10</span>),</span>
 <span id="cb45-30"><a href="#cb45-30" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
 <span id="cb45-31"><a href="#cb45-31" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Survival (%)"</span>) <span class="sc">+</span></span>
-<span id="cb45-32"><a href="#cb45-32" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb45-32"><a href="#cb45-32" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="hs-conditional" class="level2">
 <h2 class="anchored" data-anchor-id="hs-conditional">Conditional survival after hospital discharge</h2>
-<p><code>tp.hs.dead.conditional.setup.sas</code> computes individual survivorship curves starting from the time of hospital discharge rather than the operation date. The conditional survival <code>S(t | discharge)</code> is <code>S(t) / S(t_discharge)</code> for each patient. In R, the same <code>hazard_plot()</code> call is used; only the x-axis label and data preparation differ.</p>
+<p><code>tp.hs.dead.conditional.setup.sas</code> computes individual survivorship curves starting from the time of hospital discharge rather than the operation date. The conditional survival <code>S(t | discharge)</code> is <code>S(t) / S(t_discharge)</code> for each patient. In R, you use the same <code>hazard_plot()</code> call — only the x-axis label and data preparation change.</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb46"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a>dat_cond <span class="ot">&lt;-</span> <span class="fu">sample_hazard_data</span>(<span class="at">n =</span> <span class="dv">500</span>, <span class="at">time_max =</span> <span class="dv">10</span>)</span>
 <span id="cb46-2"><a href="#cb46-2" aria-hidden="true" tabindex="-1"></a>emp_cond <span class="ot">&lt;-</span> <span class="fu">sample_hazard_empirical</span>(<span class="at">n =</span> <span class="dv">500</span>, <span class="at">time_max =</span> <span class="dv">10</span>, <span class="at">n_bins =</span> <span class="dv">6</span>)</span>
 <span id="cb46-3"><a href="#cb46-3" aria-hidden="true" tabindex="-1"></a></span>
@@ -1739,7 +1739,7 @@ run;</code></pre>
 <span id="cb46-16"><a href="#cb46-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">100</span>), <span class="at">breaks =</span> <span class="fu">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dv">10</span>),</span>
 <span id="cb46-17"><a href="#cb46-17" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
 <span id="cb46-18"><a href="#cb46-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Discharge"</span>, <span class="at">y =</span> <span class="st">"Survival after Discharge (%)"</span>) <span class="sc">+</span></span>
-<span id="cb46-19"><a href="#cb46-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb46-19"><a href="#cb46-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="hs-uslife" class="level2">
 <h2 class="anchored" data-anchor-id="hs-uslife">US life-table overlay</h2>
@@ -1786,11 +1786,11 @@ run;</code></pre>
 <span id="cb47-40"><a href="#cb47-40" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
 <span id="cb47-41"><a href="#cb47-41" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years after Operation"</span>, <span class="at">y =</span> <span class="st">"Survival (%)"</span>,</span>
 <span id="cb47-42"><a href="#cb47-42" aria-hidden="true" tabindex="-1"></a>       <span class="at">caption =</span> <span class="st">"Dashed lines: US population life table"</span>) <span class="sc">+</span></span>
-<span id="cb47-43"><a href="#cb47-43" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb47-43"><a href="#cb47-43" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </section>
 <section id="hs-benefit" class="level2">
 <h2 class="anchored" data-anchor-id="hs-benefit">Treatment benefit distribution</h2>
-<p><code>tp.hs.dead.compare_benefit.setup.sas</code> computes, for each patient, the difference in predicted survival at a fixed time point (5 years) under two treatment arms (e.g.&nbsp;ASA vs.&nbsp;no ASA). The distribution of these individual differences shows who benefits and by how much. Use <code>survival_difference_plot()</code> to plot the mean curve over time.</p>
+<p><code>tp.hs.dead.compare_benefit.setup.sas</code> computes, for each patient, the difference in predicted survival at a fixed time point (5 years) under two treatment arms (e.g.&nbsp;ASA vs.&nbsp;no ASA). That per-patient distribution is the answer to “who benefits and by how much.” <code>survival_difference_plot()</code> plots the mean difference curve over time.</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb48"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a>diff_dat <span class="ot">&lt;-</span> <span class="fu">sample_survival_difference_data</span>(</span>
 <span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">n      =</span> <span class="dv">500</span>,</span>
 <span id="cb48-3"><a href="#cb48-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">groups =</span> <span class="fu">c</span>(<span class="st">"No ASA"</span> <span class="ot">=</span> <span class="fl">1.0</span>, <span class="st">"ASA"</span> <span class="ot">=</span> <span class="fl">0.75</span>)</span>
@@ -1809,7 +1809,7 @@ run;</code></pre>
 <span id="cb48-16"><a href="#cb48-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_y_continuous</span>(<span class="at">limits =</span> <span class="fu">c</span>(<span class="sc">-</span><span class="dv">5</span>, <span class="dv">40</span>),</span>
 <span id="cb48-17"><a href="#cb48-17" aria-hidden="true" tabindex="-1"></a>                     <span class="at">labels =</span> <span class="cf">function</span>(x) <span class="fu">paste0</span>(x, <span class="st">"%"</span>)) <span class="sc">+</span></span>
 <span id="cb48-18"><a href="#cb48-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">x =</span> <span class="st">"Years"</span>, <span class="at">y =</span> <span class="st">"Survival Difference (%)"</span>) <span class="sc">+</span></span>
-<span id="cb48-19"><a href="#cb48-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">hv_theme</span>(<span class="st">"poster"</span>)</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
+<span id="cb48-19"><a href="#cb48-19" aria-hidden="true" tabindex="-1"></a>  <span class="fu">theme_hv_poster</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <hr>
 </section>
 </section>
@@ -1834,13 +1834,13 @@ run;</code></pre>
 <div class="cell">
 <div class="code-copy-outer-scaffold"><div class="sourceCode cell-code" id="cb49"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="fu">sessionInfo</span>()</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div class="cell-output cell-output-stdout">
-<pre><code>R version 4.5.3 (2026-03-11)
-Platform: aarch64-apple-darwin20
-Running under: macOS Tahoe 26.4.1
+<pre><code>R version 4.6.0 (2026-04-24)
+Platform: aarch64-apple-darwin23
+Running under: macOS Tahoe 26.5
 
 Matrix products: default
-BLAS:   /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRblas.0.dylib 
-LAPACK: /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/lib/libRlapack.dylib;  LAPACK version 3.12.1
+BLAS:   /Library/Frameworks/R.framework/Versions/4.6/Resources/lib/libRblas.0.dylib 
+LAPACK: /Library/Frameworks/R.framework/Versions/4.6/Resources/lib/libRlapack.dylib;  LAPACK version 3.12.1
 
 locale:
 [1] en_US/en_US/en_US/C/en_US/en_US
@@ -1852,29 +1852,29 @@ attached base packages:
 [1] stats     graphics  grDevices utils     datasets  methods   base     
 
 other attached packages:
-[1] ggplot2_4.0.2        hvtiPlotR_2.0.0.9010
+[1] ggplot2_4.0.3   hvtiPlotR_2.3.0
 
 loaded via a namespace (and not attached):
  [1] generics_0.1.4          tidyr_1.3.2             fontLiberation_0.1.0   
  [4] xml2_1.5.2              lattice_0.22-9          digest_0.6.39          
- [7] magrittr_2.0.5          evaluate_1.0.5          grid_4.5.3             
-[10] RColorBrewer_1.1-3      fastmap_1.2.0           Matrix_1.7-4           
-[13] jsonlite_2.0.0          zip_2.3.3               survival_3.8-6         
-[16] purrr_1.2.1             scales_1.4.0            fontBitstreamVera_0.1.1
-[19] textshaping_1.0.5       cli_3.6.5               rlang_1.2.0            
-[22] fontquiver_0.2.1        splines_4.5.3           withr_3.0.2            
-[25] yaml_2.3.12             otel_0.2.0              gdtools_0.5.0          
-[28] tools_4.5.3             officer_0.7.3           uuid_1.2-2             
-[31] dplyr_1.2.1             colorspace_2.1-2        ComplexUpset_1.3.3     
-[34] vctrs_0.7.2             R6_2.6.1                lifecycle_1.0.5        
+ [7] magrittr_2.0.5          evaluate_1.0.5          grid_4.6.0             
+[10] RColorBrewer_1.1-3      fastmap_1.2.0           Matrix_1.7-5           
+[13] jsonlite_2.0.0          zip_2.3.3               consort_1.2.3          
+[16] survival_3.8-6          purrr_1.2.2             scales_1.4.0           
+[19] fontBitstreamVera_0.1.1 textshaping_1.0.5       cli_3.6.6              
+[22] rlang_1.2.0             fontquiver_0.2.1        ggupset_0.4.1          
+[25] splines_4.6.0           withr_3.0.2             yaml_2.3.12            
+[28] otel_0.2.0              gdtools_0.5.0           tools_4.6.0            
+[31] officer_0.7.5           uuid_1.2-2              dplyr_1.2.1            
+[34] vctrs_0.7.3             R6_2.6.1                lifecycle_1.0.5        
 [37] htmlwidgets_1.6.4       ragg_1.5.2              pkgconfig_2.0.3        
-[40] pillar_1.11.1           gtable_0.3.6            glue_1.8.0             
-[43] Rcpp_1.1.1              systemfonts_1.3.2       xfun_0.57              
-[46] rvg_0.4.1               tibble_3.3.1            tidyselect_1.2.1       
+[40] pillar_1.11.1           gtable_0.3.6            glue_1.8.1             
+[43] Rcpp_1.1.1-1.1          systemfonts_1.3.2       xfun_0.57              
+[46] rvg_0.4.2               tibble_3.3.1            tidyselect_1.2.1       
 [49] knitr_1.51              farver_2.1.2            htmltools_0.5.9        
-[52] patchwork_1.3.2         labeling_0.4.3          rmarkdown_2.31         
-[55] ggalluvial_0.12.6       compiler_4.5.3          S7_0.2.1               
-[58] askpass_1.2.1           openssl_2.3.5          </code></pre>
+[52] labeling_0.4.3          rmarkdown_2.31          ggalluvial_0.12.6      
+[55] compiler_4.6.0          S7_0.2.2                askpass_1.2.1          
+[58] openssl_2.4.0          </code></pre>
 </div>
 </div>
 </section>

--- a/vignettes/sas-migration-guide.qmd
+++ b/vignettes/sas-migration-guide.qmd
@@ -1100,7 +1100,7 @@ plot(lc) +
 
 `hv_mirror_hist()` replaces both scripts. Call `plot(mh)` to render.
 Diagnostics are in `mh$tables$diagnostics`, working data in
-`mh$tables$working`; layer scales and annotations the usual way.
+`mh$tables$working`; layer scales, annotations, and a theme the usual way.
 
 ## Binary-match mode (`tp.lp.mirror-histogram_SAVR-TF-TAVR.R`) {#dp-mirror-binary}
 

--- a/vignettes/sas-migration-guide.qmd
+++ b/vignettes/sas-migration-guide.qmd
@@ -47,7 +47,7 @@ up in the table below and jump to the corresponding section for a working R
 example.
 
 The guide is organized by template family (the two-letter prefix after `tp.`).
-New ports are added to this document as they become available.
+We add new ports as they become available.
 
 ## Key concepts for SAS users
 
@@ -422,7 +422,7 @@ plot(hv_nonparametric(
 **Port:** `tp.np.tr.ivecho.average_curv.ordinal.sas`
 
 Ordinal templates (TR grade, AR grade) use `hv_ordinal()`.
-The critical migration step is reshaping the SAS wide-format `predict`
+The main migration step is reshaping the SAS wide-format `predict`
 dataset (one column per grade) to long format.
 
 **SAS reshape (do this before reading into R):**
@@ -597,7 +597,7 @@ plot(hv_ordinal(dat_ph, grade_col = "grade")) +
 `hv_survival()` wraps `survfit()` from the **survival** package and returns
 an S3 object. Call `plot(km, type = ...)` to render one of the five plot types
 matching the SAS `%kaplan` / `%nelsont` macro output flags (`PLOTS`, `PLOTC`,
-`PLOTH`, `PLOTL`). Tidy data frames are accessible via `km$tables`.
+`PLOTH`, `PLOTL`). Tidy data frames live in `km$tables`.
 
 ```r
 dta <- sample_survival_data(n = 500, seed = 42)
@@ -683,9 +683,9 @@ plot(gf) +
 **R equivalent:** `hv_balance()`
 
 The SAS export arrives wide (one column per time-point). Reshape to long format
-before calling `hv_balance()`. Pass `var_levels` to control the
-bottom-to-top display order of covariates (matches `ylabel` in the original
-script).
+before you call `hv_balance()`. Pass `var_levels` to control the
+bottom-to-top display order of covariates — this matches `ylabel` in the
+original script.
 
 ```r
 # Reshape wide → long (mirrors the original script)
@@ -1098,10 +1098,9 @@ plot(lc) +
 **R equivalents:** `tp.lp.mirror-histogram_SAVR-TF-TAVR.R` (binary-match),
 `tp.lp.mirror_histo_before_after_wt.R` (weighted IPTW)
 
-Both scripts are superseded by `hv_mirror_hist()`. Call `plot(mh)` to render the
-histogram. Diagnostics are accessible via `mh$tables$diagnostics`; working
-data via `mh$tables$working`. Compose scales, annotations, and theme with the
-usual `+` operator.
+`hv_mirror_hist()` replaces both scripts. Call `plot(mh)` to render.
+Diagnostics are in `mh$tables$diagnostics`, working data in
+`mh$tables$working`; layer scales and annotations the usual way.
 
 ## Binary-match mode (`tp.lp.mirror-histogram_SAVR-TF-TAVR.R`) {#dp-mirror-binary}
 
@@ -1346,8 +1345,8 @@ hazard_plot(
 `tp.hs.dead.conditional.setup.sas` computes individual survivorship curves
 starting from the time of hospital discharge rather than the operation date.
 The conditional survival `S(t | discharge)` is `S(t) / S(t_discharge)` for
-each patient. In R, the same `hazard_plot()` call is used; only the x-axis
-label and data preparation differ.
+each patient. In R, you use the same `hazard_plot()` call — only the x-axis
+label and data preparation change.
 
 ```r
 dat_cond <- sample_hazard_data(n = 500, time_max = 10)
@@ -1428,9 +1427,8 @@ hazard_plot(
 
 `tp.hs.dead.compare_benefit.setup.sas` computes, for each patient, the
 difference in predicted survival at a fixed time point (5 years) under two
-treatment arms (e.g. ASA vs. no ASA). The distribution of these individual
-differences shows who benefits and by how much. Use `survival_difference_plot()`
-to plot the mean curve over time.
+treatment arms (e.g. ASA vs. no ASA). That per-patient distribution is the answer to "who benefits and by how much."
+`survival_difference_plot()` plots the mean difference curve over time.
 
 ```r
 diff_dat <- sample_survival_difference_data(

--- a/vignettes/sas-migration-guide.qmd
+++ b/vignettes/sas-migration-guide.qmd
@@ -63,10 +63,11 @@ plot(np) +
   theme_hv_poster()
 ```
 
-**`theme_hv_manuscript()` replaces SAS `device=` / style options.** Use
-`"dark_ppt"` / `"ppt"` for PowerPoint slides, `"light_ppt"` for
-light-background slides, `"manuscript"` for journal figures, and
-`"poster"` for conference posters.
+**The `theme_hv_*()` functions replace SAS `device=` / style options.** Use
+`theme_hv_ppt_dark()` for PowerPoint slides on dark backgrounds,
+`theme_hv_ppt_light()` for light/transparent slides,
+`theme_hv_manuscript()` for journal figures, and `theme_hv_poster()` for
+conference posters.
 
 **Functions return a ggplot object; they do not display it.** Call the
 plot object at the top level (or use `print()`) to render it, or save with

--- a/writing-voice.md
+++ b/writing-voice.md
@@ -1,0 +1,68 @@
+# John Ehrlinger — Writing Voice Fingerprint
+
+Reference for keeping documentation and prose in a consistent human voice.
+Canonical copy lives in the Obsidian vault; package repos hold a synced copy.
+
+## The voice in one line
+
+Pedagogical and conversational: start from something the reader already knows,
+build to the new idea with a concrete analogy, and don't be afraid of a little
+personality or a slightly imperfect sentence.
+
+## Two registers
+
+**Narrative** (vignettes, README, roxygen @description/@details, methods prose)
+- Open from the familiar: "Most readers are familiar with simple linear regression..."
+- Carry one concrete analogy through a hard idea (a fruit basket, the blind men
+  and the elephant, a "noise-reduction filter").
+- Question-headed sections: "Why Cluster?", "Where Do We Stop?".
+- First person plural: "in our practice", "we proceed". Address the reader as "you".
+- Gloss terms inline in parentheses; scare-quote a piece of jargon the first
+  time it appears ("rules", "elbow", "eyeballing").
+- Start sentences with But / Yet / Thus / Now when it helps the flow.
+- **Conversational, not chatty.** A colleague explaining the method at a
+  whiteboard, not a blog post. Keep an analogy when it teaches; cut winking
+  asides and cute phrasing. "no Tukey rule hiding in the middle" is too cute;
+  "not the usual Tukey 1.5 IQR whiskers" is right. Plain and direct beats
+  folksy. The reader is a peer, so don't perform for them.
+- Vary sentence length. A short flat statement after a long one lands well.
+
+**Terse** (roxygen @param/@return, NEWS bullets)
+- Compressed, but still plain and concrete, not sterile.
+- State the thing; skip the preamble. "Logical; if TRUE, ..." not "This
+  argument controls whether...".
+- No analogies, no question headers here; the voice shows in word choice.
+
+## Rules
+
+- Em-dashes: use sparingly. Native to the voice and honestly overused. Keep one
+  where it earns the pause; otherwise a comma, parentheses, or a full stop.
+- Ellipses: an informal-register habit (text, email). Keep them out of package docs.
+- Don't overstate. No overselling. Cut "enhanced", "powerful", "seamlessly",
+  "robust" (as a brag), "comprehensive". State what the thing does, at its size.
+- Imperfection is allowed. Mild redundancy, an occasional long sentence: human
+  texture, not an error to scrub. Don't polish to a glassy finish.
+- Repetition that teaches is voice, not defect. Restating a concept, or a
+  callback structure (state the problems up front, answer each later), is kept.
+  Repeat when it clarifies; cut repetition that only fills space.
+
+## AI tells to hunt and kill
+
+- Mechanical parallelism: same-shaped sentences with no teaching purpose, lists
+  padded to equal length. (Pedagogical repetition is NOT this; preserve it.)
+- Flavorlessness: correct but with no analogy, no picture, nothing a person
+  would actually say.
+- Missing "we"/"you": abstract, authorless prose.
+- Forced tricolons: "fast, simple, and reliable".
+- Hedge-free sterile balance: "X. However, Y. It is worth noting Z."
+- Overstatement (see Rules).
+- "in order to", "it is important to note", "leverage", "utilize".
+
+Punctuation density is NOT a tell. The tells are structural.
+
+## Before / after
+
+AI:   "Set per_class = TRUE to enable the computation of per-class one-vs-rest
+       ROC curves, providing enhanced flexibility for multi-class analysis."
+John: "Set per_class = TRUE and a multi-class forest gives you one ROC curve
+       per class, each class scored against all the others."


### PR DESCRIPTION
## Summary

Patches the package to **v2.3.1** with a package-wide documentation voice rewrite and a handful of doc bug fixes. **Prose only — no behavioural, API, or code changes.**

### Voice rewrite
Built brainstorm → spec → plan → subagent-driven execution. Each artifact was rewritten by one subagent and reviewed by another for facts-preserved + voice-quality, against `memory/writing-voice.md`.

- `README.md`
- 5 vignettes — `hvtiPlotR`, `plot-functions`, `plot-decorators`, `sas-migration-guide`, `contributing`
- `NEWS.md` — all version entries (Terse register; every version, `#nn`, and fact preserved)
- `inst/slides/hvtiPlotR-whats-new.qmd`
- roxygen `@description`/`@details` (narrative) and `@param`/`@return` (terse) across `R/*.R`
- `DESCRIPTION` `Title:` field

### Doc bug fixes (caught by Copilot review)
- Stale `hv_theme()` string-key references (`"dark_ppt"`, `"ppt"`, `"light_ppt"`, etc.) in the main tutorial and SAS-migration vignettes — that dispatcher was removed in 2.1.0; the vignettes now name the actual `theme_hv_*()` functions.
- "is simplify" → "is to simplify" grammar in the main tutorial intro.
- README listed four vignettes when five ship; the "SAS migration guide" comment was misattached to the main tutorial; the "Migrating from plot.sas" section pointed at the wrong vignette.

### Also in this branch
- Re-rendered the four tracked vignette HTML files.
- Switched the slide deck revealjs theme `solarized` → `default` (an earlier change).
- Synced `writing-voice.md` into the repo root (`.Rbuildignore`'d).

### Verification
- `devtools::test()` — 0 failures
- `devtools::check()` — 0 errors, 0 warnings (1 pre-existing `Rplots.pdf` NOTE)
- All 4 re-rendered vignettes execute every chunk cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)