### PR TITLE
release: hvtiPlotR 2.3.2 — vignette clarity pass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hvtiPlotR
 Type: Package
 Title: HVTI ggplot2 themes and clinical plot functions for the Cleveland Clinic Heart & Vascular Institute
-Version: 2.3.1
-Date: 2026-05-22
+Version: 2.3.2
+Date: 2026-05-27
 Authors@R: c(
     person(
       "John", "Ehrlinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# hvtiPlotR 2.3.2
+
+## Documentation (#70)
+
+- Vignette clarity pass: added structural grounding to all five vignettes —
+  two to four sentences before every code chunk on what the recipe does, when
+  to reach for it, and (for bare/raw plots) what to look for. Applied the
+  `memory/vignette-clarity-pass.md` workflow developed for TemporalHazard 1.0.3.
+- Corrected four factual claims surfaced by review: the dashed-threshold
+  recommendation in the SAS migration guide (`geom_hline()`, not
+  `annotate("hline")`); the `theme_hv_poster()` font claim (the theme does
+  not enforce a sans-serif face); the `theme(legend.position = "none")`
+  layout-space claim (no space is reserved); and the `theme_hv_manuscript()`
+  "no title" claim (the theme does not blank `plot.title`).
+
 # hvtiPlotR 2.3.1
 
 ## Documentation (#69)


### PR DESCRIPTION
## Summary

Patches the package to **v2.3.2** to surface the vignette clarity pass (PR #70) in `news()`. Documentation only — no behavioural, API, or code changes.

### NEWS entry

```markdown
# hvtiPlotR 2.3.2

## Documentation (#70)

- Vignette clarity pass: added structural grounding to all five vignettes —
  two to four sentences before every code chunk on what the recipe does, when
  to reach for it, and (for bare/raw plots) what to look for. Applied the
  `memory/vignette-clarity-pass.md` workflow developed for TemporalHazard 1.0.3.
- Corrected four factual claims surfaced by review: the dashed-threshold
  recommendation in the SAS migration guide (`geom_hline()`, not
  `annotate("hline")`); the `theme_hv_poster()` font claim (the theme does
  not enforce a sans-serif face); the `theme(legend.position = "none")`
  layout-space claim (no space is reserved); and the `theme_hv_manuscript()`
  "no title" claim (the theme does not blank `plot.title`).
```

### Verification (carried over from PR #70)

- `devtools::test()` — 0 failures
- `devtools::check()` — 0 errors, 0 warnings (1 pre-existing `Rplots.pdf` NOTE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)