### PR TITLE
chore: CRAN release-gate audit — clean R CMD check --as-cran (0/0/0)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -41,3 +41,5 @@ hvtiPlotR.Rproj
 ^.*\.fuse_hidden
 ^\.positai$
 ^writing-voice\.md$
+^Rplots\.pdf$
+^.*\.tar\.gz$

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ docs
 hvtiPlotR.Rproj
 
 .claude
-.Rcheck*
+*.Rcheck/
 .Rproj.user
 .Rhistory
 .RData

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ hvtiPlotR.Rproj
 /Meta/
 .fuse_hidden*
 .positai
+Rplots.pdf
+*.tar.gz

--- a/R/alluvial-plot.R
+++ b/R/alluvial-plot.R
@@ -38,7 +38,7 @@
 #' @examples
 #' dta <- sample_alluvial_data(n = 300, seed = 42)
 #' head(dta)
-#' # Axes in order: pre-op grade → procedure → post-op grade
+#' # Axes in order: pre-op grade -> procedure -> post-op grade
 #' with(dta, tapply(freq, list(pre_ar, post_ar), sum, default = 0))
 #' @export
 sample_alluvial_data <- function(n = 300, seed = 42L) {

--- a/R/cluster-sankey-plot.R
+++ b/R/cluster-sankey-plot.R
@@ -289,8 +289,7 @@ print.hv_sankey <- function(x, ...) {
 #'     theme_hv_poster()
 #' }
 #'
-#' @importFrom ggplot2 ggplot aes geom_vline labs scale_fill_manual theme
-#'   element_blank
+#' @importFrom ggplot2 ggplot aes geom_vline labs scale_fill_manual theme element_blank
 #' @importFrom rlang .data
 #' @export
 plot.hv_sankey <- function(x,

--- a/R/covariate-balance.R
+++ b/R/covariate-balance.R
@@ -22,8 +22,7 @@ cb_validate_params <- function(threshold, point_size, hline_linewidth,
 }
 
 #' @importFrom rlang .data
-#' @importFrom ggplot2 ggplot aes geom_vline geom_hline geom_point
-#'   scale_y_continuous
+#' @importFrom ggplot2 ggplot aes geom_vline geom_hline geom_point scale_y_continuous
 cb_build_plot <- function(data, std_diff_col, group_col, var_levels,
                           threshold, point_size, alpha,
                           hline_linetype, hline_linewidth,
@@ -234,8 +233,7 @@ print.hv_balance <- function(x, ...) {
 #'   ggplot2::labs(x = "Standardized difference (%)", y = "") +
 #'   theme_hv_poster()
 #'
-#' @importFrom ggplot2 ggplot aes geom_vline geom_hline geom_point
-#'   scale_y_continuous
+#' @importFrom ggplot2 ggplot aes geom_vline geom_hline geom_point scale_y_continuous
 #' @export
 plot.hv_balance <- function(x,
                               point_size         = 3,

--- a/R/eda-plots.R
+++ b/R/eda-plots.R
@@ -378,8 +378,7 @@ print.hv_eda <- function(x, ...) {
 #'                     size = 3, colour = "grey40", fontface = "italic") +
 #'   theme_hv_poster()
 #'
-#' @importFrom ggplot2 ggplot aes geom_point geom_smooth geom_rug geom_bar
-#'   scale_y_continuous labs
+#' @importFrom ggplot2 ggplot aes geom_point geom_smooth geom_rug geom_bar scale_y_continuous labs
 #' @importFrom rlang .data
 #' @export
 plot.hv_eda <- function(x,

--- a/R/hazard-plot.R
+++ b/R/hazard-plot.R
@@ -101,15 +101,15 @@
 #' with `PROC LIFEREG`.
 #'
 #' **SAS column mapping:**
-#' - `time`         ← `YEARS` / `iv_dead` (prediction grid)
-#' - `survival`     ← `SSURVIV` (predicted survival, 0–100 %)
-#' - `surv_lower`   ← `SCLLSURV` (lower confidence limit on survival)
-#' - `surv_upper`   ← `SCLUSURV` (upper confidence limit on survival)
-#' - `hazard`       ← predicted hazard rate (%/year)
-#' - `haz_lower`    ← lower confidence limit on hazard
-#' - `haz_upper`    ← upper confidence limit on hazard
-#' - `cumhaz`       ← cumulative hazard (%; corresponds to `-log(S)*100`)
-#' - `group`        ← group stratification variable (when `groups` is not `NULL`)
+#' - `time`         <- `YEARS` / `iv_dead` (prediction grid)
+#' - `survival`     <- `SSURVIV` (predicted survival, 0–100 %)
+#' - `surv_lower`   <- `SCLLSURV` (lower confidence limit on survival)
+#' - `surv_upper`   <- `SCLUSURV` (upper confidence limit on survival)
+#' - `hazard`       <- predicted hazard rate (%/year)
+#' - `haz_lower`    <- lower confidence limit on hazard
+#' - `haz_upper`    <- upper confidence limit on hazard
+#' - `cumhaz`       <- cumulative hazard (%; corresponds to `-log(S)*100`)
+#' - `group`        <- group stratification variable (when `groups` is not `NULL`)
 #'
 #' @param n        Number of patients used to scale confidence-limit width.
 #'   Default `500`.
@@ -123,7 +123,7 @@
 #'   (late mortality); `shape < 1` gives decreasing hazard (early operative
 #'   mortality). Default `1.5`.
 #' @param scale    Weibull scale parameter (characteristic time in years, i.e.
-#'   the time at which `S = exp(-1) ≈ 37%`). Default `8.0`.
+#'   the time at which `S = exp(-1)` \eqn{\approx} 37%). Default `8.0`.
 #' @param ci_level Confidence level for the CI bands. Default `0.95`.
 #' @param seed     Random seed (unused for deterministic Weibull predictions;
 #'   kept for API consistency with other sample functions). Default `42`.
@@ -201,11 +201,11 @@ sample_hazard_data <- function(n        = 500,
 #' overlay in `tp.hp.dead.sas` and related templates.
 #'
 #' **SAS column mapping:**
-#' - `time`     ← `IV_DEAD` / `iv_dead` (evaluation time points)
-#' - `estimate` ← `CUM_SURV` (KM survival estimate, 0–100 %)
-#' - `lower`    ← `CL_LOWER` (lower 95 % CI)
-#' - `upper`    ← `CL_UPPER` (upper 95 % CI)
-#' - `group`    ← stratification variable (when `groups` is not `NULL`)
+#' - `time`     <- `IV_DEAD` / `iv_dead` (evaluation time points)
+#' - `estimate` <- `CUM_SURV` (KM survival estimate, 0–100 %)
+#' - `lower`    <- `CL_LOWER` (lower 95 % CI)
+#' - `upper`    <- `CL_UPPER` (upper 95 % CI)
+#' - `group`    <- stratification variable (when `groups` is not `NULL`)
 #'
 #' @param n        Number of simulated patients. Default `500`.
 #' @param time_max Upper end of the follow-up window (years). Default `10`.
@@ -268,9 +268,9 @@ sample_hazard_empirical <- function(n        = 500,
 #' `tp.hp.dead.uslife.stratifed.sas`.
 #'
 #' **SAS column mapping:**
-#' - `time`     ← prediction time grid (years)
-#' - `survival` ← `SMATCHED` (age-group-specific survivorship, 0–100 %)
-#' - `group`    ← age group label (e.g. `"<65"`, `"65-80"`, `"\u226580"`)
+#' - `time`     <- prediction time grid (years)
+#' - `survival` <- `SMATCHED` (age-group-specific survivorship, 0–100 %)
+#' - `group`    <- age group label (e.g. `"<65"`, `"65-80"`, `"\u226580"`)
 #'
 #' @param age_groups Character vector of age group labels. Default
 #'   `c("<65", "65-80", "\u226580")`.
@@ -284,7 +284,7 @@ sample_hazard_empirical <- function(n        = 500,
 #' @seealso [hv_hazard()], [sample_hazard_data()]
 #'
 #' @examples
-#' # Default: three age groups (<65, 65-80, ≥80) using Gompertz mortality
+#' # Default: three age groups (<65, 65-80, 80+) using Gompertz mortality
 #' lt <- sample_life_table(time_max = 10)
 #' head(lt)
 #' nlevels(lt$group)    # 3 age groups
@@ -298,10 +298,12 @@ sample_hazard_empirical <- function(n        = 500,
 #' )
 #' levels(lt2$group)
 #' @export
-sample_life_table <- function(age_groups = c("<65", "65-80", "\u226580"),
+sample_life_table <- function(age_groups = NULL,
                                age_mids   = c(55, 72, 85),
                                time_max   = 10,
                                n_points   = 100) {
+  if (is.null(age_groups))
+    age_groups <- c("<65", "65-80", "\u226580")
   if (length(age_groups) != length(age_mids))
     stop("`age_groups` and `age_mids` must have the same length.", call. = FALSE)
 
@@ -335,12 +337,12 @@ sample_life_table <- function(age_groups = c("<65", "65-80", "\u226580"),
 #' `tp.hp.dead.life-gained.sas`.
 #'
 #' **SAS column mapping:**
-#' - `time`        ← prediction grid
-#' - `difference`  ← survival(group 2) - survival(group 1) (percentage points)
-#' - `diff_lower`  ← lower CI on difference
-#' - `diff_upper`  ← upper CI on difference
-#' - `group1_surv` ← survival curve for group 1
-#' - `group2_surv` ← survival curve for group 2
+#' - `time`        <- prediction grid
+#' - `difference`  <- survival(group 2) - survival(group 1) (percentage points)
+#' - `diff_lower`  <- lower CI on difference
+#' - `diff_upper`  <- upper CI on difference
+#' - `group1_surv` <- survival curve for group 1
+#' - `group2_surv` <- survival curve for group 2
 #'
 #' @param n        Number of patients per group (used for CI width). Default `500`.
 #' @param time_max Upper end of the time axis (years). Default `10`.
@@ -414,11 +416,11 @@ sample_survival_difference_data <- function(n        = 500,
 #' of `tp.hp.numtreat.survdiff.matched.sas`.
 #'
 #' **SAS column mapping:**
-#' - `time`      ← prediction grid (years)
-#' - `arr`       ← absolute risk reduction (survival difference, %)
-#' - `arr_lower` / `arr_upper` ← CI on ARR
-#' - `nnt`       ← number needed to treat (= 100 / ARR)
-#' - `nnt_lower` / `nnt_upper` ← CI on NNT (inverted from ARR CI)
+#' - `time`      <- prediction grid (years)
+#' - `arr`       <- absolute risk reduction (survival difference, %)
+#' - `arr_lower` / `arr_upper` <- CI on ARR
+#' - `nnt`       <- number needed to treat (= 100 / ARR)
+#' - `nnt_lower` / `nnt_upper` <- CI on NNT (inverted from ARR CI)
 #'
 #' @inheritParams sample_survival_difference_data
 #'
@@ -494,13 +496,13 @@ sample_nnt_data <- function(n        = 500,
 #' | Age as x-axis (tp.hp.dead.age_on_horizontal_axis.sas) | `x_col="age"` |
 #'
 #' **SAS column mapping:**
-#' - `x_col`          ← `YEARS` / `iv_dead`
-#' - `estimate_col`   ← `SSURVIV` (survival), `hazard` (%/yr), or `cumhaz`
-#' - `lower_col`      ← `SCLLSURV` / `cll_p95`
-#' - `upper_col`      ← `SCLUSURV` / `clu_p95`
-#' - `group_col`      ← treatment/group indicator variable
-#' - `empirical`      ← the `plout` / `acpdms` KM output dataset
-#' - `reference`      ← the `smatched` life-table dataset
+#' - `x_col`          <- `YEARS` / `iv_dead`
+#' - `estimate_col`   <- `SSURVIV` (survival), `hazard` (%/yr), or `cumhaz`
+#' - `lower_col`      <- `SCLLSURV` / `cll_p95`
+#' - `upper_col`      <- `SCLUSURV` / `clu_p95`
+#' - `group_col`      <- treatment/group indicator variable
+#' - `empirical`      <- the `plout` / `acpdms` KM output dataset
+#' - `reference`      <- the `smatched` life-table dataset
 #'
 #' Returns a **bare ggplot object**; compose with `scale_colour_*`,
 #' `scale_y_continuous()`, `labs()`, [theme_hv_manuscript()].
@@ -1163,7 +1165,7 @@ survival_difference_plot <- function(diff_data,
 #' @param estimate_col Name of the NNT column. Default `"nnt"`.
 #' @param lower_col    Name of the lower CI column, or `NULL`. Default `NULL`.
 #' @param upper_col    Name of the upper CI column, or `NULL`. Default `NULL`.
-#' @param na_rm        Remove `NA` NNT values (undefined when ARR ≈ 0) before
+#' @param na_rm        Remove `NA` NNT values (undefined when ARR \eqn{\approx} 0) before
 #'   plotting. Default `TRUE`.
 #' @param ci_alpha     Transparency of the CI ribbon. Default `0.20`.
 #' @param line_width   Line width. Default `1.0`.

--- a/R/kaplan-meier.R
+++ b/R/kaplan-meier.R
@@ -11,8 +11,8 @@
 ## (PLOTS, PLOTC, PLOTH, PLOTL) plus associated data frames (tidy KM data,
 ## numbers-at-risk table, and a report table at user-supplied time points).
 ##
-## method = "kaplan-meier"  →  %kaplan  (product-limit, logit CI)
-## method = "nelson-aalen"  →  %nelsont (Fleming-Harrington, log CI on H)
+## method = "kaplan-meier"  ->  %kaplan  (product-limit, logit CI)
+## method = "nelson-aalen"  ->  %nelsont (Fleming-Harrington, log CI on H)
 ##
 ## Quick start
 ## -----------
@@ -55,7 +55,7 @@ km_fit <- function(data, time_col, event_col, group_col, conf_level, method) {
   t_ <- data[[time_col]]
   e_ <- data[[event_col]]
 
-  # method → survfit type and CI transform
+  # method -> survfit type and CI transform
   # "kaplan-meier": product-limit S(t), logit CI  — matches SAS %kaplan
   # "nelson-aalen": Fleming-Harrington H(t), log CI — matches SAS %nelsont
   surv_type <- if (method == "kaplan-meier") "kaplan-meier" else "fleming-harrington"
@@ -667,8 +667,7 @@ print.hv_survival <- function(x, ...) {
 #'   ggplot2::labs(x = "Years", y = "Instantaneous Hazard") +
 #'   theme_hv_poster()
 #'
-#' @importFrom ggplot2 ggplot aes geom_step geom_ribbon geom_hline
-#'   scale_y_continuous geom_point
+#' @importFrom ggplot2 ggplot aes geom_step geom_ribbon geom_hline scale_y_continuous geom_point
 #' @export
 plot.hv_survival <- function(x,
                                type     = c("survival", "cumhaz",

--- a/R/longitudinal-counts-plot.R
+++ b/R/longitudinal-counts-plot.R
@@ -231,8 +231,7 @@ print.hv_longitudinal <- function(x, ...) {
 #' # p_table <- plot(lc, type = "table")  + <decorators>
 #' # p_bar / p_table + patchwork::plot_layout(heights = c(3, 1))
 #'
-#' @importFrom ggplot2 ggplot aes geom_bar geom_text scale_y_discrete theme
-#'   element_blank
+#' @importFrom ggplot2 ggplot aes geom_bar geom_text scale_y_discrete theme element_blank
 #' @importFrom rlang .data
 #' @export
 plot.hv_longitudinal <- function(x,

--- a/R/mirror-histogram.R
+++ b/R/mirror-histogram.R
@@ -622,8 +622,8 @@ sample_mirror_histogram_data <- function(n          = 500,
   set.seed(seed)
 
   # Logistic propensity score model.
-  # Control LP ~ N(-sep/2, 1) → scores cluster below 0.5.
-  # Treated LP ~ N(+sep/2, 1) → scores cluster above 0.5.
+  # Control LP ~ N(-sep/2, 1) -> scores cluster below 0.5.
+  # Treated LP ~ N(+sep/2, 1) -> scores cluster above 0.5.
   # The further a patient sits from 0.5, the fewer matching partners exist.
   ps_ctrl <- stats::plogis(stats::rnorm(n, mean = -separation / 2, sd = 1))
   ps_trt  <- stats::plogis(stats::rnorm(n, mean =  separation / 2, sd = 1))

--- a/R/nonparametric-curve-plot.R
+++ b/R/nonparametric-curve-plot.R
@@ -37,7 +37,7 @@
   eta_intercept = -0.5,   # log-odds shift; centres baseline P(event) ≈ 18 %
   logit_shift   = -1.2,   # additional logit shift; P(event) ≈ 12 % at t = 0
   cont_baseline =  40,    # continuous outcome baseline (e.g. AV gradient, mmHg)
-  cont_scale    =   8,    # eta → mmHg scaling factor
+  cont_scale    =   8,    # eta -> mmHg scaling factor
   cont_sigma    =   6,    # residual SD (mmHg measurement noise)
   eff_frac_prob =   0.1,  # effective-patient fraction per time point (probability)
   eff_frac_cont =   0.05  # effective-patient fraction per time point (continuous)
@@ -282,11 +282,11 @@ sample_nonparametric_curve_points <- function(n            = 500,
 #' | Phase decomposition (`phases`, `independence`) | \code{+ group_col = "phase"} |
 #'
 #' **SAS column mapping:**
-#' - \code{estimate_col} ← \code{prev}, \code{mnprev}, \code{_p_},
+#' - \code{estimate_col} <- \code{prev}, \code{mnprev}, \code{_p_},
 #'   \code{est_fev}, \code{est_z0d}
-#' - \code{lower_col} ← \code{cll_p68} or \code{cll_p95}
-#' - \code{upper_col} ← \code{clu_p68} or \code{clu_p95}
-#' - \code{group_col} ← indicator added after wide-to-long reshape
+#' - \code{lower_col} <- \code{cll_p68} or \code{cll_p95}
+#' - \code{upper_col} <- \code{clu_p68} or \code{clu_p95}
+#' - \code{group_col} <- indicator added after wide-to-long reshape
 #'
 #' @param curve_data  Data frame; one row per (time, group) combination.
 #' @param x_col       Name of the x-axis column. Default \code{"time"}.

--- a/R/nonparametric-ordinal-plot.R
+++ b/R/nonparametric-ordinal-plot.R
@@ -208,10 +208,10 @@ sample_nonparametric_ordinal_points <- function(
 #' colour scales and \code{\link{theme_hv_manuscript}}.
 #'
 #' **SAS column mapping (\code{predict} dataset after averaging):**
-#' - \code{time} ← \code{iv_echo} (or \code{iv_wristm})
-#' - \code{estimate} ← one of \code{p0}, \code{p1}, \code{p2}, \code{p3}
+#' - \code{time} <- \code{iv_echo} (or \code{iv_wristm})
+#' - \code{estimate} <- one of \code{p0}, \code{p1}, \code{p2}, \code{p3}
 #'   (individual grade probs, after wide-to-long reshape)
-#' - \code{grade} ← a new column created during the reshape
+#' - \code{grade} <- a new column created during the reshape
 #'
 #' @param curve_data  Long-format data frame: one row per (time, grade)
 #'   combination. Columns: \code{x_col}, \code{estimate_col}, \code{grade_col}.

--- a/R/spaghetti-plot.R
+++ b/R/spaghetti-plot.R
@@ -243,8 +243,7 @@ print.hv_spaghetti <- function(x, ...) {
 #' # See vignette("plot-decorators", package = "hvtiPlotR") for theming,
 #' # colour scales, annotation labels, and saving plots.
 #'
-#' @importFrom ggplot2 ggplot aes geom_line geom_smooth scale_colour_identity
-#'   scale_y_continuous
+#' @importFrom ggplot2 ggplot aes geom_line geom_smooth scale_colour_identity scale_y_continuous
 #' @importFrom rlang .data
 #' @export
 plot.hv_spaghetti <- function(x,

--- a/R/upset-plot.R
+++ b/R/upset-plot.R
@@ -248,8 +248,7 @@ print.hv_upset <- function(x, ...) {
 #' }
 #'
 #' @importFrom ggupset scale_x_upset
-#' @importFrom ggplot2 aes geom_bar geom_col ggplot labs scale_x_reverse
-#'   element_blank theme
+#' @importFrom ggplot2 aes geom_bar geom_col ggplot labs scale_x_reverse element_blank theme
 #' @export
 plot.hv_upset <- function(x,
                           n_intersections   = 10L,

--- a/man/hazard_plot.Rd
+++ b/man/hazard_plot.Rd
@@ -127,13 +127,13 @@ the full \verb{tp.hp.dead.*} SAS template family.\tabular{ll}{
 
 \strong{SAS column mapping:}
 \itemize{
-\item \code{x_col}          ← \code{YEARS} / \code{iv_dead}
-\item \code{estimate_col}   ← \code{SSURVIV} (survival), \code{hazard} (\%/yr), or \code{cumhaz}
-\item \code{lower_col}      ← \code{SCLLSURV} / \code{cll_p95}
-\item \code{upper_col}      ← \code{SCLUSURV} / \code{clu_p95}
-\item \code{group_col}      ← treatment/group indicator variable
-\item \code{empirical}      ← the \code{plout} / \code{acpdms} KM output dataset
-\item \code{reference}      ← the \code{smatched} life-table dataset
+\item \code{x_col}          <- \code{YEARS} / \code{iv_dead}
+\item \code{estimate_col}   <- \code{SSURVIV} (survival), \code{hazard} (\%/yr), or \code{cumhaz}
+\item \code{lower_col}      <- \code{SCLLSURV} / \code{cll_p95}
+\item \code{upper_col}      <- \code{SCLUSURV} / \code{clu_p95}
+\item \code{group_col}      <- treatment/group indicator variable
+\item \code{empirical}      <- the \code{plout} / \code{acpdms} KM output dataset
+\item \code{reference}      <- the \code{smatched} life-table dataset
 }
 
 Returns a \strong{bare ggplot object}; compose with \verb{scale_colour_*},

--- a/man/hv_nonparametric.Rd
+++ b/man/hv_nonparametric.Rd
@@ -68,11 +68,11 @@ Covers the full range of \code{tp.np.*} SAS templates:\tabular{ll}{
 
 \strong{SAS column mapping:}
 \itemize{
-\item \code{estimate_col} ← \code{prev}, \code{mnprev}, \code{_p_},
+\item \code{estimate_col} <- \code{prev}, \code{mnprev}, \code{_p_},
 \code{est_fev}, \code{est_z0d}
-\item \code{lower_col} ← \code{cll_p68} or \code{cll_p95}
-\item \code{upper_col} ← \code{clu_p68} or \code{clu_p95}
-\item \code{group_col} ← indicator added after wide-to-long reshape
+\item \code{lower_col} <- \code{cll_p68} or \code{cll_p95}
+\item \code{upper_col} <- \code{clu_p68} or \code{clu_p95}
+\item \code{group_col} <- indicator added after wide-to-long reshape
 }
 }
 \examples{

--- a/man/hv_ordinal.Rd
+++ b/man/hv_ordinal.Rd
@@ -47,10 +47,10 @@ colour scales and \code{\link{theme_hv_manuscript}}.
 \details{
 \strong{SAS column mapping (\code{predict} dataset after averaging):}
 \itemize{
-\item \code{time} ← \code{iv_echo} (or \code{iv_wristm})
-\item \code{estimate} ← one of \code{p0}, \code{p1}, \code{p2}, \code{p3}
+\item \code{time} <- \code{iv_echo} (or \code{iv_wristm})
+\item \code{estimate} <- one of \code{p0}, \code{p1}, \code{p2}, \code{p3}
 (individual grade probs, after wide-to-long reshape)
-\item \code{grade} ← a new column created during the reshape
+\item \code{grade} <- a new column created during the reshape
 }
 }
 \examples{

--- a/man/nnt_plot.Rd
+++ b/man/nnt_plot.Rd
@@ -27,7 +27,7 @@ nnt_plot(
 
 \item{upper_col}{Name of the upper CI column, or \code{NULL}. Default \code{NULL}.}
 
-\item{na_rm}{Remove \code{NA} NNT values (undefined when ARR ≈ 0) before
+\item{na_rm}{Remove \code{NA} NNT values (undefined when ARR \eqn{\approx} 0) before
 plotting. Default \code{TRUE}.}
 
 \item{ci_alpha}{Transparency of the CI ribbon. Default \code{0.20}.}

--- a/man/sample_alluvial_data.Rd
+++ b/man/sample_alluvial_data.Rd
@@ -29,7 +29,7 @@ post-operatively following valve surgery.
 \examples{
 dta <- sample_alluvial_data(n = 300, seed = 42)
 head(dta)
-# Axes in order: pre-op grade → procedure → post-op grade
+# Axes in order: pre-op grade -> procedure -> post-op grade
 with(dta, tapply(freq, list(pre_ar, post_ar), sum, default = 0))
 }
 \seealso{

--- a/man/sample_hazard_data.Rd
+++ b/man/sample_hazard_data.Rd
@@ -33,7 +33,7 @@ group indicator in \code{tp.hp.dead.tkdn.stratified.sas}.}
 mortality). Default \code{1.5}.}
 
 \item{scale}{Weibull scale parameter (characteristic time in years, i.e.
-the time at which \verb{S = exp(-1) ≈ 37\%}). Default \code{8.0}.}
+the time at which \code{S = exp(-1)} \eqn{\approx} 37\%). Default \code{8.0}.}
 
 \item{ci_level}{Confidence level for the CI bands. Default \code{0.95}.}
 
@@ -54,15 +54,15 @@ with \verb{PROC LIFEREG}.
 \details{
 \strong{SAS column mapping:}
 \itemize{
-\item \code{time}         ← \code{YEARS} / \code{iv_dead} (prediction grid)
-\item \code{survival}     ← \code{SSURVIV} (predicted survival, 0–100 \%)
-\item \code{surv_lower}   ← \code{SCLLSURV} (lower confidence limit on survival)
-\item \code{surv_upper}   ← \code{SCLUSURV} (upper confidence limit on survival)
-\item \code{hazard}       ← predicted hazard rate (\%/year)
-\item \code{haz_lower}    ← lower confidence limit on hazard
-\item \code{haz_upper}    ← upper confidence limit on hazard
-\item \code{cumhaz}       ← cumulative hazard (\%; corresponds to \code{-log(S)*100})
-\item \code{group}        ← group stratification variable (when \code{groups} is not \code{NULL})
+\item \code{time}         <- \code{YEARS} / \code{iv_dead} (prediction grid)
+\item \code{survival}     <- \code{SSURVIV} (predicted survival, 0–100 \%)
+\item \code{surv_lower}   <- \code{SCLLSURV} (lower confidence limit on survival)
+\item \code{surv_upper}   <- \code{SCLUSURV} (upper confidence limit on survival)
+\item \code{hazard}       <- predicted hazard rate (\%/year)
+\item \code{haz_lower}    <- lower confidence limit on hazard
+\item \code{haz_upper}    <- upper confidence limit on hazard
+\item \code{cumhaz}       <- cumulative hazard (\%; corresponds to \code{-log(S)*100})
+\item \code{group}        <- group stratification variable (when \code{groups} is not \code{NULL})
 }
 }
 \examples{

--- a/man/sample_hazard_empirical.Rd
+++ b/man/sample_hazard_empirical.Rd
@@ -47,11 +47,11 @@ overlay in \code{tp.hp.dead.sas} and related templates.
 \details{
 \strong{SAS column mapping:}
 \itemize{
-\item \code{time}     ← \code{IV_DEAD} / \code{iv_dead} (evaluation time points)
-\item \code{estimate} ← \code{CUM_SURV} (KM survival estimate, 0–100 \%)
-\item \code{lower}    ← \code{CL_LOWER} (lower 95 \% CI)
-\item \code{upper}    ← \code{CL_UPPER} (upper 95 \% CI)
-\item \code{group}    ← stratification variable (when \code{groups} is not \code{NULL})
+\item \code{time}     <- \code{IV_DEAD} / \code{iv_dead} (evaluation time points)
+\item \code{estimate} <- \code{CUM_SURV} (KM survival estimate, 0–100 \%)
+\item \code{lower}    <- \code{CL_LOWER} (lower 95 \% CI)
+\item \code{upper}    <- \code{CL_UPPER} (upper 95 \% CI)
+\item \code{group}    <- stratification variable (when \code{groups} is not \code{NULL})
 }
 }
 \examples{

--- a/man/sample_life_table.Rd
+++ b/man/sample_life_table.Rd
@@ -5,7 +5,7 @@
 \title{Sample Population Life Table Data}
 \usage{
 sample_life_table(
-  age_groups = c("<65", "65-80", "≥80"),
+  age_groups = NULL,
   age_mids = c(55, 72, 85),
   time_max = 10,
   n_points = 100
@@ -34,13 +34,13 @@ mortality, matching the US population life table overlays used in
 \details{
 \strong{SAS column mapping:}
 \itemize{
-\item \code{time}     ← prediction time grid (years)
-\item \code{survival} ← \code{SMATCHED} (age-group-specific survivorship, 0–100 \%)
-\item \code{group}    ← age group label (e.g. \code{"<65"}, \code{"65-80"}, \code{"\\u226580"})
+\item \code{time}     <- prediction time grid (years)
+\item \code{survival} <- \code{SMATCHED} (age-group-specific survivorship, 0–100 \%)
+\item \code{group}    <- age group label (e.g. \code{"<65"}, \code{"65-80"}, \code{"\\u226580"})
 }
 }
 \examples{
-# Default: three age groups (<65, 65-80, ≥80) using Gompertz mortality
+# Default: three age groups (<65, 65-80, 80+) using Gompertz mortality
 lt <- sample_life_table(time_max = 10)
 head(lt)
 nlevels(lt$group)    # 3 age groups

--- a/man/sample_nnt_data.Rd
+++ b/man/sample_nnt_data.Rd
@@ -46,11 +46,11 @@ of \code{tp.hp.numtreat.survdiff.matched.sas}.
 \details{
 \strong{SAS column mapping:}
 \itemize{
-\item \code{time}      ← prediction grid (years)
-\item \code{arr}       ← absolute risk reduction (survival difference, \%)
-\item \code{arr_lower} / \code{arr_upper} ← CI on ARR
-\item \code{nnt}       ← number needed to treat (= 100 / ARR)
-\item \code{nnt_lower} / \code{nnt_upper} ← CI on NNT (inverted from ARR CI)
+\item \code{time}      <- prediction grid (years)
+\item \code{arr}       <- absolute risk reduction (survival difference, \%)
+\item \code{arr_lower} / \code{arr_upper} <- CI on ARR
+\item \code{nnt}       <- number needed to treat (= 100 / ARR)
+\item \code{nnt_lower} / \code{nnt_upper} <- CI on NNT (inverted from ARR CI)
 }
 }
 \examples{

--- a/man/sample_survival_difference_data.Rd
+++ b/man/sample_survival_difference_data.Rd
@@ -46,12 +46,12 @@ matching the output of the \code{HAZDIFL} macro used in
 \details{
 \strong{SAS column mapping:}
 \itemize{
-\item \code{time}        ← prediction grid
-\item \code{difference}  ← survival(group 2) - survival(group 1) (percentage points)
-\item \code{diff_lower}  ← lower CI on difference
-\item \code{diff_upper}  ← upper CI on difference
-\item \code{group1_surv} ← survival curve for group 1
-\item \code{group2_surv} ← survival curve for group 2
+\item \code{time}        <- prediction grid
+\item \code{difference}  <- survival(group 2) - survival(group 1) (percentage points)
+\item \code{diff_lower}  <- lower CI on difference
+\item \code{diff_upper}  <- upper CI on difference
+\item \code{group1_surv} <- survival curve for group 1
+\item \code{group2_surv} <- survival curve for group 2
 }
 }
 \examples{

--- a/vignettes/hvtiPlotR.html
+++ b/vignettes/hvtiPlotR.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="John Ehrlinger ehrlinj@ccf.org">
-<meta name="dcterms.date" content="2026-05-27">
+<meta name="dcterms.date" content="2026-05-28">
 
 <title>The hvtiPlotR package: Generating plot.sas style in R</title>
 <style>
@@ -159,7 +159,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 27, 2026</p>
+      <p class="date">May 28, 2026</p>
     </div>
   </div>
   
@@ -825,7 +825,7 @@ run;</code></pre>
 <section id="colors" class="level2">
 <h2 class="anchored" data-anchor-id="colors">Colors</h2>
 <p>You can specify colors in R by numeric index, name (as we have done), hexadecimal, or RGB specification. For example <code>col=1</code> and <code>col="white"</code> are equivalent. The chart in Figure 9 was produced with code developed by Glynn (2005). See his R Color Chart website for all the details you would ever need about using colors in R.</p>
-<p>ColorBrewer (Harrower and Brewer 2003) is an online tool (http://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We recommend it as a practical starting point for choosing colors grounded in sound design principles.</p>
+<p>ColorBrewer (Harrower and Brewer 2003) is an online tool (https://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We recommend it as a practical starting point for choosing colors grounded in sound design principles.</p>
 <p>Figure 8: ggplot2 shape table</p>
 <p>Figure 9: R colors</p>
 <p>The ColorBrewer palette catalogue (Harrower and Brewer 2003) is built into <code>ggplot2</code> via <code>scale_colour_brewer()</code> / <code>scale_fill_brewer()</code>; hvtiPlotR does not import the optional <code>RColorBrewer</code> package. We have made extensive use of the <code>palette = "Set1"</code> colour palette in the figures we have generated. There are also a series of other <code>scale_colour_*</code> functions in ggplot2 to aid the user in selecting good colour schemes for many diﬀerent settings — consult <a href="https://colorbrewer2.org/" class="uri">https://colorbrewer2.org/</a> for an interactive palette browser.</p>
@@ -1007,11 +1007,8 @@ run;</code></pre>
 </section>
 <section id="references" class="level1">
 <h1>References</h1>
-<p>Auguie B (2012). gridExtra: functions in Grid graphics. R package version 0.9.1, URL http://CRAN.R-project.org/package=gridExtra.</p>
-<p>Glynn EF (2005). “R Color Chart.” http://research.stowers-institute.org/efg/R/ Color/Chart/index.htm. Accessed: 2014-09-16.</p>
-<p>Gohel D (2014). ReporteRs: Microsoft Word, Microsoft Powerpoint and HTML docu- ments generation from R. R package version 0.6.1, URL http://davidgohel.github. io/ReporteRs/index.html,http://groups.google.com/group/reporters-package.</p>
-<p>Harrower M, Brewer CA (2003). “ColorBrewer.org: An Online Tool for Selecting Colour Schemes for Maps.” The Cartographic Journal, pp.&nbsp;27–37. doi:10.1179/ 000870403235002042. URL http://colorbrewer2.org/.</p>
-<p>Neuwirth E (2011). RColorBrewer: ColorBrewer palettes. R package version 1.0-5, URL http://CRAN.R-project.org/package=RColorBrewer.</p>
+<p>Gohel D, Skintzos P (2024). officer: Manipulation of Microsoft Word and PowerPoint Documents. R package version 0.6.5, URL https://CRAN.R-project.org/package=officer.</p>
+<p>Harrower M, Brewer CA (2003). “ColorBrewer.org: An Online Tool for Selecting Colour Schemes for Maps.” The Cartographic Journal, pp.&nbsp;27–37. doi:10.1179/000870403235002042. URL https://colorbrewer2.org/.</p>
 <p>Wickham H (2009). ggplot2: elegant graphics for data analysis. Springer New York. ISBN 978-0-387-98140-6.</p>
 <p>Wilkinson L (2005). The Grammar of Graphics (Statistics and Computing). Springer-Verlag New York, Inc., Secaucus, NJ, USA. ISBN 0387245448.</p>
 </section>

--- a/vignettes/hvtiPlotR.qmd
+++ b/vignettes/hvtiPlotR.qmd
@@ -520,7 +520,7 @@ The shape argument takes numeric arguments. Though not user friendly, this metho
 ## Colors 
 You can specify colors in R by numeric index, name (as we have done), hexadecimal, or RGB specification. For example `col=1` and `col="white"` are equivalent. The chart in Figure 9 was produced with code developed by Glynn (2005). See his R Color Chart website for all the details you would ever need about using colors in R.
 
-ColorBrewer (Harrower and Brewer 2003) is an online tool (http://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We recommend it as a practical starting point for choosing colors grounded in sound design principles.
+ColorBrewer (Harrower and Brewer 2003) is an online tool (https://colorbrewer2.org/) designed to help people select good color schemes for maps and other graphics. We recommend it as a practical starting point for choosing colors grounded in sound design principles.
 
 
 Figure 8: ggplot2 shape table
@@ -722,15 +722,9 @@ them; the rest are conventions to keep in mind when composing figures.
 In this article, we present the **hvtiPlotR** package for R. The package is made up of ggplot2 themes for publication quality graphics, as well as this tutorial document included as a package vignette. The package is available from https://github.com/ehrlinger/hvtiPlotR and can be installed using the `remotes::install_github("ehrlinger/hvtiPlotR")` command. 
 
 # References 
-Auguie B (2012). gridExtra: functions in Grid graphics. R package version 0.9.1, URL http://CRAN.R-project.org/package=gridExtra. 
+Gohel D, Skintzos P (2024). officer: Manipulation of Microsoft Word and PowerPoint Documents. R package version 0.6.5, URL https://CRAN.R-project.org/package=officer.
 
-Glynn EF (2005). "R Color Chart." http://research.stowers-institute.org/efg/R/ Color/Chart/index.htm. Accessed: 2014-09-16. 
-
-Gohel D (2014). ReporteRs: Microsoft Word, Microsoft Powerpoint and HTML docu- ments generation from R. R package version 0.6.1, URL http://davidgohel.github. io/ReporteRs/index.html,http://groups.google.com/group/reporters-package. 
-
-Harrower M, Brewer CA (2003). "ColorBrewer.org: An Online Tool for Selecting Colour Schemes for Maps." The Cartographic Journal, pp. 27–37. doi:10.1179/ 000870403235002042. URL http://colorbrewer2.org/. 
-
-Neuwirth E (2011). RColorBrewer: ColorBrewer palettes. R package version 1.0-5, URL http://CRAN.R-project.org/package=RColorBrewer. 
+Harrower M, Brewer CA (2003). "ColorBrewer.org: An Online Tool for Selecting Colour Schemes for Maps." The Cartographic Journal, pp. 27–37. doi:10.1179/000870403235002042. URL https://colorbrewer2.org/.
 
 Wickham H (2009). ggplot2: elegant graphics for data analysis. Springer New York. ISBN 978-0-387-98140-6. 
 


### PR DESCRIPTION
## Summary

Brings the package to a clean release baseline ahead of the next set of changes. `R CMD check --as-cran` (with the manual build) now reports **0 errors / 0 warnings / 0 notes**, and `urlchecker::url_check()` passes.

- **Roxygen 8.0.0 `@importFrom` failures** — collapsed wrapped multi-line `@importFrom` tags across 8 files (roxygen2 8.0.0 rejects them).
- **Raw Unicode breaking the PDF manual** (the failure `--no-manual` hides) — math symbols in roxygen prose now use `\eqn{}`; SAS-mapping arrows became ASCII `<-`/`->`; `sample_life_table()`'s `≥80` default moved into the body via a `NULL` sentinel so output keeps the symbol while `\usage` stays ASCII.
- **Top-level `Rplots.pdf` NOTE** — ignore `Rplots.pdf` and `*.tar.gz` in `.Rbuildignore`/`.gitignore`, removed stray graphics-device output.
- **Stale vignette references** — defunct ReporteRs → `officer`; dropped unused gridExtra/RColorBrewer/404'd R Color Chart; canonicalized `http→https`; regenerated `hvtiPlotR.html`.
- **`.gitignore` fix** — `.Rcheck*` → `*.Rcheck/` so check output dirs are actually ignored.

No version bump — DESCRIPTION and NEWS remain at 2.3.2 (clean baseline).

## Test plan

- [x] `devtools::document()` — clean
- [x] `devtools::check(cran = TRUE, manual = TRUE)` — 0/0/0 including PDF manual
- [x] `urlchecker::url_check()` — all URLs correct
- [x] `git check-ignore hvtiPlotR.Rcheck` — confirms new ignore pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)