### PR TITLE
fix: correct save_ppt() panel_box defaults (v2.3.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hvtiPlotR
 Type: Package
 Title: HVTI ggplot2 themes and clinical plot functions for the Cleveland Clinic Heart & Vascular Institute
-Version: 2.3.3
+Version: 2.3.4
 Date: 2026-06-03
 Authors@R: c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# hvtiPlotR 2.3.4
+
+## Bug fixes
+
+- `save_ppt()`: corrected `panel_box` defaults to
+  `list(width = 8.79, height = 4.422, left = 2.67, top = 1.29)`.
+
 # hvtiPlotR 2.3.3
 
 ## Bug fixes

--- a/R/save_ppt.R
+++ b/R/save_ppt.R
@@ -376,10 +376,10 @@ save_ppt <- function(object,
                      height       = 5.8,
                      left         = 0.0,
                      top          = 1.2,
-                     panel_box    = list(width  = 8.88,
-                                         height = 4.51,
-                                         left   = 2.58,
-                                         top    = 1.63)) {
+                     panel_box    = list(width  = 8.79,
+                                         height = 4.422,
+                                         left   = 2.67,
+                                         top    = 1.29)) {
 
   ensure_officer_available()
   ensure_rvg_available()

--- a/tests/testthat/test_save_ppt.R
+++ b/tests/testthat/test_save_ppt.R
@@ -376,7 +376,7 @@ test_that("save_ppt defaults panel_box to the standard fixed-panel rectangle", {
   default_box <- eval(formals(save_ppt)$panel_box)
   expect_equal(
     default_box,
-    list(width = 8.88, height = 4.51, left = 2.58, top = 1.63)
+    list(width = 8.79, height = 4.422, left = 2.67, top = 1.29)
   )
 })
 


### PR DESCRIPTION
## Summary

- Corrects `panel_box` default in `save_ppt()` from `(8.88 × 4.51 @ 2.58, 1.63)` to `(8.79 × 4.422 @ 2.67, 1.29)`
- Updates matching test assertion
- Bumps version to 2.3.4

## Test Plan

- [x] `devtools::test()` — 1299 PASS, 0 FAIL, 0 SKIP