### PR TITLE
fix: theme paper arg controls plot.background; clarify show_yaxis/venn theme docs (v2.6.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hvtiPlotR
 Type: Package
 Title: HVTI ggplot2 themes and clinical plot functions for the Cleveland Clinic Heart & Vascular Institute
-Version: 2.6.0
-Date: 2026-06-03
+Version: 2.6.1
+Date: 2026-06-24
 Authors@R: c(
     person(
       "John", "Ehrlinger",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# hvtiPlotR 2.6.1
+
+## Bug fixes
+
+- `theme_hv_poster()`, `theme_hv_ppt_dark()`, `theme_hv_ppt_light()`: the `paper`
+  argument now controls the figure background (`plot.background` fill). It was
+  hard-coded to `"transparent"`, so passing `paper` had no effect. The PPT themes
+  still default to transparent (the slide background shows through);
+  `theme_hv_poster()` now honours its `"white"` default.
+
+## Documentation
+
+- `plot.hv_alluvial()`: clarify that `show_yaxis = FALSE` is a `theme()` layer, so
+  a complete theme added afterward (e.g. `theme_hv_manuscript()`) re-asserts the
+  axis it styles.
+- `plot.hv_venn()`: note the diagram is coordinate-free — do not add an
+  axis-bearing house theme, which pastes spurious axes onto it. Example updated.
+
 # hvtiPlotR 2.6.0
 
 ## New features

--- a/R/alluvial-plot.R
+++ b/R/alluvial-plot.R
@@ -213,8 +213,11 @@ print.hv_alluvial <- function(x, ...) {
 #' @param show_labels   Logical; if TRUE, each stratum is labelled. Default \code{TRUE}.
 #' @param show_yaxis    Logical; if FALSE, the y-axis title, text, ticks, and
 #'   line are blanked for a clean milestone patient-flow look (the
-#'   alluvium/stratum geometry is untouched and remains composable with a
-#'   later \code{theme()}). Default \code{TRUE} (counts shown).
+#'   alluvium/stratum geometry is untouched). Default \code{TRUE} (counts shown).
+#'   Note the blanking is a \code{theme()} layer, so a \emph{complete} theme
+#'   added afterward (e.g. \code{theme_hv_manuscript()}) re-asserts the axis it
+#'   styles; add the theme first and re-blank, or blank the y elements yourself
+#'   after it, when you want both the house theme and a clean axis.
 #' @param ...           Ignored; present for S3 consistency.
 #'
 #' @return A bare \code{\link[ggplot2]{ggplot}} object.

--- a/R/themes.R
+++ b/R/themes.R
@@ -116,7 +116,7 @@ theme_hv_poster <- function(base_size      = 16,
                    base_line_size, base_rect_size,
                    ink, paper, accent) %+replace%
     theme(
-      plot.background    = element_rect(fill = "transparent",
+      plot.background    = element_rect(fill = paper,
                                         colour = "transparent",
                                         linewidth = 2),
       axis.text          = element_text(size = base_size, colour = "black"),
@@ -165,7 +165,7 @@ theme_hv_ppt_dark <- function(base_size      = 32,
                    base_line_size, base_rect_size,
                    ink, paper, accent) %+replace%
     theme(
-      plot.background    = element_rect(fill = "transparent",
+      plot.background    = element_rect(fill = paper,
                                         colour = "transparent",
                                         linewidth = 2),
       axis.text          = element_text(size = base_size, colour = "white",
@@ -216,7 +216,7 @@ theme_hv_ppt_light <- function(base_size      = 32,
                    base_line_size, base_rect_size,
                    ink, paper, accent) %+replace%
     theme(
-      plot.background    = element_rect(fill = "transparent",
+      plot.background    = element_rect(fill = paper,
                                         colour = "transparent",
                                         linewidth = 2),
       axis.text          = element_text(size = base_size, colour = "black",

--- a/R/venn-plot.R
+++ b/R/venn-plot.R
@@ -115,15 +115,19 @@ hv_venn <- function(data, sets) {
 #'   most \code{plot.hv_*} methods, which ignore \code{...}; \pkg{ggvenn} bakes
 #'   labels into its geoms, so forwarding is the only way to reach them).
 #'
-#' @return A \code{\link[ggplot2]{ggplot}} object. Compose with
-#'   \code{\link{theme_hv_manuscript}}, \code{labs()}, etc.
+#' @return A \code{\link[ggplot2]{ggplot}} object, already styled by
+#'   \pkg{ggvenn} and \strong{coordinate-free} (no axes). Tune it through this
+#'   method's arguments (\code{fill}, \code{text_size}, \code{set_name_size},
+#'   \code{...}). Do \emph{not} add an axis-bearing house theme such as
+#'   \code{theme_hv_manuscript()}: a Venn has no meaningful x/y, and the theme
+#'   would paste spurious axes onto it.
 #'
 #' @seealso \code{\link{hv_venn}}
 #'
 #' @examples
 #' dta <- sample_upset_data(n = 300, seed = 42)
 #' v   <- hv_venn(dta, sets = c("AV_Replacement", "MV_Replacement", "CABG"))
-#' plot(v) + theme_hv_manuscript()
+#' plot(v)
 #'
 #' @export
 plot.hv_venn <- function(x, show_percentage = TRUE, show_counts = TRUE,

--- a/man/plot.hv_alluvial.Rd
+++ b/man/plot.hv_alluvial.Rd
@@ -34,8 +34,11 @@ spacing. Default \code{1/4}.}
 
 \item{show_yaxis}{Logical; if FALSE, the y-axis title, text, ticks, and
 line are blanked for a clean milestone patient-flow look (the
-alluvium/stratum geometry is untouched and remains composable with a
-later \code{theme()}). Default \code{TRUE} (counts shown).}
+alluvium/stratum geometry is untouched). Default \code{TRUE} (counts shown).
+Note the blanking is a \code{theme()} layer, so a \emph{complete} theme
+added afterward (e.g. \code{theme_hv_manuscript()}) re-asserts the axis it
+styles; add the theme first and re-blank, or blank the y elements yourself
+after it, when you want both the house theme and a clean axis.}
 
 \item{...}{Ignored; present for S3 consistency.}
 }

--- a/man/plot.hv_venn.Rd
+++ b/man/plot.hv_venn.Rd
@@ -34,8 +34,12 @@ most \code{plot.hv_*} methods, which ignore \code{...}; \pkg{ggvenn} bakes
 labels into its geoms, so forwarding is the only way to reach them).}
 }
 \value{
-A \code{\link[ggplot2]{ggplot}} object. Compose with
-\code{\link{theme_hv_manuscript}}, \code{labs()}, etc.
+A \code{\link[ggplot2]{ggplot}} object, already styled by
+\pkg{ggvenn} and \strong{coordinate-free} (no axes). Tune it through this
+method's arguments (\code{fill}, \code{text_size}, \code{set_name_size},
+\code{...}). Do \emph{not} add an axis-bearing house theme such as
+\code{theme_hv_manuscript()}: a Venn has no meaningful x/y, and the theme
+would paste spurious axes onto it.
 }
 \description{
 Draws a 2-3 set Venn diagram using \code{ggvenn::ggvenn()} and returns a
@@ -44,7 +48,7 @@ bare \pkg{ggplot2} object you can finish with \code{+}.
 \examples{
 dta <- sample_upset_data(n = 300, seed = 42)
 v   <- hv_venn(dta, sets = c("AV_Replacement", "MV_Replacement", "CABG"))
-plot(v) + theme_hv_manuscript()
+plot(v)
 
 }
 \seealso{

--- a/tests/testthat/test_themes.R
+++ b/tests/testthat/test_themes.R
@@ -226,3 +226,19 @@ test_that("hv_theme dispatcher has been removed", {
   expect_false(exists("hv_theme", mode = "function",
                       envir = asNamespace("hvtiPlotR")))
 })
+
+# ============================================================================
+# `paper` argument controls plot.background fill (regression: was hard-coded
+# "transparent", ignoring the argument)
+# ============================================================================
+
+test_that("paper sets plot.background fill in ppt and poster themes", {
+  expect_identical(theme_hv_ppt_dark(paper  = "grey15")$plot.background$fill, "grey15")
+  expect_identical(theme_hv_ppt_light(paper = "ivory")$plot.background$fill,  "ivory")
+  expect_identical(theme_hv_poster(paper    = "navy")$plot.background$fill,   "navy")
+})
+
+test_that("ppt themes still default plot.background to transparent", {
+  expect_identical(theme_hv_ppt_dark()$plot.background$fill,  "transparent")
+  expect_identical(theme_hv_ppt_light()$plot.background$fill, "transparent")
+})


### PR DESCRIPTION
## Summary

Closes the three theme-ordering items surfaced while wiring hvtiPlotR 2.5/2.6 into the recipes book.

- **`paper` argument (bug fix).** `theme_hv_poster()`, `theme_hv_ppt_dark()`, and `theme_hv_ppt_light()` hard-coded `plot.background = element_rect(fill = "transparent")`, so the `paper` argument had **no effect**. It now sets the fill. The PPT themes still default to transparent (slide background shows through); `theme_hv_poster()` now honours its `"white"` default. (This is why the book's dark-slide preview had to override `plot.background` by hand — now `theme_hv_ppt_dark(paper = "grey15")` just works.)
- **`plot.hv_alluvial()` doc.** Clarify that `show_yaxis = FALSE` is a `theme()` layer, so a *complete* theme added afterward (`theme_hv_manuscript()`) re-asserts the axis it styles.
- **`plot.hv_venn()` doc + example.** The diagram is coordinate-free (ggvenn); a house theme pastes spurious axes onto it. `@return` and the `@example` (which had recommended `+ theme_hv_manuscript()`) updated to drop the theme.

## Test plan
- [x] New tests: `paper` sets `plot.background$fill` for poster + both PPT themes; PPT themes still default transparent
- [x] Full suite: **0 failures / 1396 pass** (4 pre-existing warnings, 2 skips)
- [x] `devtools::document()` re-run (man/*.Rd updated)
- [ ] `R CMD check --as-cran` (running; this PR) — please confirm 0/0/0 before release

## Version
Bumped to **2.6.1** (DESCRIPTION + NEWS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)