### PR TITLE
feat: hv_legend_inside() prefer= argument (v2.7.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hvtiPlotR
 Type: Package
 Title: HVTI ggplot2 themes and clinical plot functions for the Cleveland Clinic Heart & Vascular Institute
-Version: 2.7.1
+Version: 2.7.2
 Date: 2026-06-24
 Authors@R: c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# hvtiPlotR 2.7.2
+
+## New features
+
+- `hv_legend_inside()` gains a `prefer` argument: name a corner
+  (`"topright"`/`"topleft"`/`"bottomright"`/`"bottomleft"`) and the legend goes
+  there when that corner is clear, even if another corner is emptier. When the
+  preferred corner is occupied it falls back to the emptiest-corner logic, so the
+  occlusion guard is never given up.
+
 # hvtiPlotR 2.7.1
 
 ## New features

--- a/R/legend-inside.R
+++ b/R/legend-inside.R
@@ -84,6 +84,11 @@
 #' @param fallback Outside `legend.position` used when no corner is empty enough
 #'   or the plot cannot be reasoned about (facets). One of `"right"`, `"left"`,
 #'   `"top"`, `"bottom"`. Default `"right"`.
+#' @param prefer Optional preferred corner: one of `"topright"`, `"topleft"`,
+#'   `"bottomright"`, `"bottomleft"`. When set and that corner is clear (its
+#'   occupancy is within `threshold`), the legend is placed there even if another
+#'   corner is emptier. If the preferred corner is occupied, the emptiest-corner
+#'   logic applies as usual. Default `NULL` (pick the emptiest corner).
 #'
 #' @return The input `plot` with a \code{\link[ggplot2]{theme}} layer added that
 #'   sets the legend position.
@@ -101,10 +106,16 @@
 #' @importFrom ggplot2 ggplot_build theme
 #' @export
 hv_legend_inside <- function(plot, threshold = 0.08, box_frac = 0.30,
-                             pad = 0.02, fallback = "right") {
+                             pad = 0.02, fallback = "right", prefer = NULL) {
   if (!inherits(plot, "ggplot"))
     stop("`plot` must be a ggplot object.", call. = FALSE)
   fallback <- match.arg(fallback, c("right", "left", "top", "bottom"))
+  if (!is.null(prefer)) {
+    prefer <- match.arg(prefer, c("topright", "topleft",
+                                  "bottomright", "bottomleft"))
+    prefer <- c(topright = "tr", topleft = "tl",
+                bottomright = "br", bottomleft = "bl")[[prefer]]
+  }
   .legend_validate(threshold, box_frac, pad)
 
   fb <- ggplot2::theme(legend.position = fallback)
@@ -119,7 +130,12 @@ hv_legend_inside <- function(plot, threshold = 0.08, box_frac = 0.30,
   pts <- .legend_points(b)
   if (is.null(pts) || nrow(pts) == 0L) return(plot + fb)
 
-  occ  <- .legend_corner_occupancy(pts$x, pts$y, box_frac)
+  occ <- .legend_corner_occupancy(pts$x, pts$y, box_frac)
+
+  # A clear preferred corner wins, even if another corner is emptier.
+  if (!is.null(prefer) && occ[[prefer]] <= threshold)
+    return(plot + .legend_corner_theme(prefer, pad))
+
   best <- names(occ)[which.min(occ)]   # ties -> first: tr, tl, br, bl
   if (occ[[best]] <= threshold)
     plot + .legend_corner_theme(best, pad)

--- a/man/hv_legend_inside.Rd
+++ b/man/hv_legend_inside.Rd
@@ -9,7 +9,8 @@ hv_legend_inside(
   threshold = 0.08,
   box_frac = 0.3,
   pad = 0.02,
-  fallback = "right"
+  fallback = "right",
+  prefer = NULL
 )
 }
 \arguments{
@@ -28,6 +29,12 @@ Default \code{0.02}.}
 \item{fallback}{Outside \code{legend.position} used when no corner is empty enough
 or the plot cannot be reasoned about (facets). One of \code{"right"}, \code{"left"},
 \code{"top"}, \code{"bottom"}. Default \code{"right"}.}
+
+\item{prefer}{Optional preferred corner: one of \code{"topright"}, \code{"topleft"},
+\code{"bottomright"}, \code{"bottomleft"}. When set and that corner is clear (its
+occupancy is within \code{threshold}), the legend is placed there even if another
+corner is emptier. If the preferred corner is occupied, the emptiest-corner
+logic applies as usual. Default \code{NULL} (pick the emptiest corner).}
 }
 \value{
 The input \code{plot} with a \code{\link[ggplot2]{theme}} layer added that

--- a/tests/testthat/test_legend_inside.R
+++ b/tests/testthat/test_legend_inside.R
@@ -90,6 +90,16 @@ test_that("hv_legend_inside falls through when the preferred corner is occupied"
   expect_identical(p$theme$legend.position, "right")   # TR full -> fallback
 })
 
+test_that("hv_legend_inside falls through to the emptiest corner when `prefer` is blocked", {
+  # Top-right occupied but top-left clear: prefer = "topright" is skipped and the
+  # legend lands in the emptiest corner (top-left), NOT the outside fallback.
+  df <- data.frame(x = c(0, 1, 1, 0.5, 0.9), y = c(0, 0, 1, 0.5, 0.1), g = "a")
+  p  <- hv_legend_inside(ggplot(df, aes(x, y, colour = g)) + geom_point(),
+                         prefer = "topright")
+  expect_identical(p$theme$legend.position, "inside")
+  expect_equal(p$theme$legend.position.inside, c(0.02, 1 - 0.02))  # top-left
+})
+
 test_that("hv_legend_inside rejects a bad `prefer`", {
   expect_error(hv_legend_inside(mk(full_df), prefer = "middle"))
 })

--- a/tests/testthat/test_legend_inside.R
+++ b/tests/testthat/test_legend_inside.R
@@ -72,3 +72,24 @@ test_that("hv_legend_inside reads coordinates in built (post-flip) space", {
   )
   expect_identical(p$theme$legend.position, "inside")
 })
+
+test_that("hv_legend_inside honours `prefer` when that corner is clear", {
+  # Both top corners empty (points along the bottom + one centre-top); the
+  # default picks top-right (tie -> tr first), `prefer` overrides to top-left.
+  df <- data.frame(x = c(0, 0.5, 1, 0.5), y = c(0, 0, 0, 1), g = "a")
+  p  <- ggplot(df, aes(x, y, colour = g)) + geom_point()
+  expect_equal(hv_legend_inside(p)$theme$legend.position.inside,
+               c(1 - 0.02, 1 - 0.02))                       # default: top-right
+  p2 <- hv_legend_inside(p, prefer = "topleft")
+  expect_identical(p2$theme$legend.position, "inside")
+  expect_equal(p2$theme$legend.position.inside, c(0.02, 1 - 0.02))  # top-left
+})
+
+test_that("hv_legend_inside falls through when the preferred corner is occupied", {
+  p <- hv_legend_inside(mk(full_df), prefer = "topright")
+  expect_identical(p$theme$legend.position, "right")   # TR full -> fallback
+})
+
+test_that("hv_legend_inside rejects a bad `prefer`", {
+  expect_error(hv_legend_inside(mk(full_df), prefer = "middle"))
+})


### PR DESCRIPTION
## Summary

Adds a **`prefer`** argument to `hv_legend_inside()` — a *soft* corner preference. Name a corner (`"topright"`, `"topleft"`, `"bottomright"`, `"bottomleft"`) and the legend goes there **when that corner is clear** (occupancy ≤ `threshold`), even if another corner is emptier. When the preferred corner is occupied, it falls back to the normal emptiest-corner logic (and the outside `fallback` if no corner is clear) — so the occlusion guard is never given up.

This resolves the both-corners-empty cases from the book adoption (e.g. the rising hazard curve, the declining survival overlay) where you wanted a *specific* empty corner without losing the auto-dodge.

```r
hv_legend_inside(p, prefer = "topleft")
```

## Test plan
- [x] New tests: prefer honored when clear (overrides a tie), prefer ignored when occupied (falls through to fallback), bad value errors
- [x] Full suite: **0 failed / 1433 pass**
- [x] `R CMD check --as-cran` (with manual) — running on this PR
- [x] roxygen `@param` + NEWS; version **2.7.2** (patch)

## Follow-up
Once released, the book's relocated figures (hazard, temporal_hazard survival) can pin their original corner via `prefer =`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)